### PR TITLE
Fix example and loss normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,14 @@ for lat in range(-90, 90, 1):
         lat_lons.append((lat, lon))
 model = GraphWeatherForecaster(lat_lons)
 
-features = torch.randn((2, len(lat_lons), 78))
+# Generate 78 random features + 24 non-NWP features (i.e. landsea mask)
+features = torch.randn((2, len(lat_lons), 102))
 
+target = torch.randn((2, len(lat_lons), 78))
 out = model(features)
+
 criterion = NormalizedMSELoss(lat_lons=lat_lons, feature_variance=torch.randn((78,)))
-loss = criterion(out, features)
+loss = criterion(out, target)
 loss.backward()
 ```
 

--- a/graph_weather/models/losses.py
+++ b/graph_weather/models/losses.py
@@ -6,7 +6,7 @@ import torch
 class NormalizedMSELoss(torch.nn.Module):
     """Loss function described in the paper"""
 
-    def __init__(self, feature_variance: list, lat_lons: list, device="cpu"):
+    def __init__(self, feature_variance: list, lat_lons: list, device="cpu", normalize: bool = False):
         """
         Normalized MSE Loss as described in the paper
 
@@ -31,6 +31,7 @@ class NormalizedMSELoss(torch.nn.Module):
         for lat, lon in lat_lons:
             weights.append(np.cos(lat * np.pi / 180.0))
         self.weights = torch.tensor(weights, dtype=torch.float)
+        self.normalize = normalize
         assert not torch.isnan(self.weights).any()
 
     def forward(self, pred: torch.Tensor, target: torch.Tensor):
@@ -50,10 +51,11 @@ class NormalizedMSELoss(torch.nn.Module):
         self.feature_variance = self.feature_variance.to(pred.device)
         self.weights = self.weights.to(pred.device)
 
-        # pred = pred / self.feature_variance
-        # target = target / self.feature_variance
-
         out = (pred - target) ** 2
+        
+        if self.normalize:
+             out = out / self.feature_variance
+
         assert not torch.isnan(out).any()
         # Mean of the physical variables
         out = out.mean(-1)

--- a/graph_weather/models/losses.py
+++ b/graph_weather/models/losses.py
@@ -6,7 +6,9 @@ import torch
 class NormalizedMSELoss(torch.nn.Module):
     """Loss function described in the paper"""
 
-    def __init__(self, feature_variance: list, lat_lons: list, device="cpu", normalize: bool = False):
+    def __init__(
+        self, feature_variance: list, lat_lons: list, device="cpu", normalize: bool = False
+    ):
         """
         Normalized MSE Loss as described in the paper
 
@@ -52,9 +54,9 @@ class NormalizedMSELoss(torch.nn.Module):
         self.weights = self.weights.to(pred.device)
 
         out = (pred - target) ** 2
-        
+
         if self.normalize:
-             out = out / self.feature_variance
+            out = out / self.feature_variance
 
         assert not torch.isnan(out).any()
         # Mean of the physical variables

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -201,3 +201,21 @@ def test_forecaster_and_loss_grad_checkpoint():
     assert not torch.isnan(out).any()
     assert not torch.isnan(out).any()
     loss.backward()
+
+def test_normalized_loss():
+    lat_lons = []
+    for lat in range(-90, 90, 5):
+        for lon in range(0, 360, 5):
+            lat_lons.append((lat, lon))
+
+    # Generate output as strictly positive random features
+    out = torch.rand((2, len(lat_lons), 78))+0.0001
+    feature_variance = (out ** 2)
+    target = torch.zeros((2, len(lat_lons), 78))
+
+    criterion = NormalizedMSELoss(lat_lons=lat_lons, feature_variance=feature_variance, normalize=True)
+    loss = criterion(out, target)
+
+    assert not torch.isnan(loss)
+    # Since feature_variance = out**2 and target = 0, we expect loss = weights
+    assert torch.isclose(loss, criterion.weights.expand_as(out.mean(-1)).mean())

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -202,6 +202,7 @@ def test_forecaster_and_loss_grad_checkpoint():
     assert not torch.isnan(out).any()
     loss.backward()
 
+
 def test_normalized_loss():
     lat_lons = []
     for lat in range(-90, 90, 5):
@@ -209,11 +210,13 @@ def test_normalized_loss():
             lat_lons.append((lat, lon))
 
     # Generate output as strictly positive random features
-    out = torch.rand((2, len(lat_lons), 78))+0.0001
-    feature_variance = (out ** 2)
+    out = torch.rand((2, len(lat_lons), 78)) + 0.0001
+    feature_variance = out**2
     target = torch.zeros((2, len(lat_lons), 78))
 
-    criterion = NormalizedMSELoss(lat_lons=lat_lons, feature_variance=feature_variance, normalize=True)
+    criterion = NormalizedMSELoss(
+        lat_lons=lat_lons, feature_variance=feature_variance, normalize=True
+    )
     loss = criterion(out, target)
 
     assert not torch.isnan(loss)


### PR DESCRIPTION
# Pull Request

## Description

1) In the example of the readme file, each features has a size of 78, whereas the model expects a feature size of 102, since the default value for "aux_dim" is 24. I've changed this number, moreover the loss is computed against a new variable target of size 78, randomly generated. This addresses the issue #83.

2) Many standard deviations in the file "consts.py" look suspiciously small (10^-6). As a consequence, the uncommented NormalizedMSELoss results in NaNs or very large values (~10^22). In the original paper, they normalize the loss by dividing the outputs and targets by the standard deviation, while in our code (currently commented), we are dividing by the variance. I added a normalization flag to the loss and modified its normalization. Now the model can train with the normalized loss, although the loss remains substantially big (~10^11). This addresses the issue #29 

## How Has This Been Tested?

I added a new test for the normalized loss.

- [x] Yes

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
