### PR TITLE
Excluding Torch version 2.2.0

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -18,7 +18,11 @@ jobs:
             torchvision-version: 0.15.1
           - torch-version: 2.2.0
             torchvision-version: 0.17.0
-
+        exclude:
+          - python-version: "3.12"
+            torch-version: 2.0.0
+          - python-version: "3.12"
+            torch-version: 2.1.0
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -54,11 +58,11 @@ jobs:
           echo "Will be looking at coverage of dir  graph_weather"
           #
           # install pytest-cov
-          pip install coverage==6.2 # https://github.com/nedbat/coveragepy/issues/1312
+          pip install coverage==7.4.3
           pip install pytest-cov
           #
           # make PYTESTCOV
-          export PYTESTCOV="--cov=graph_weather--cov-report=xml"
+          export PYTESTCOV="--cov=graph_weather tests/ --cov-report=xml"
           # echo results and save env var for other jobs
           echo "pytest-cov options that will be used are: $PYTESTCOV"
           echo "PYTESTCOV=$PYTESTCOV" >> $GITHUB_ENV


### PR DESCRIPTION
Excluding torch version 2.2.0 with Python 3.12 until fixed.  https://github.com/pytorch/pytorch/issues/110436
Also updated py-coverage versions and directory.

# Pull Request

## Description

I excluded the torch version 2.2.0 for Python version 3.12 within the testing "workflow.yaml". Also updated pytest-cov and passed the correct directory to the action.

Fixes #

## How Has This Been Tested?
Tested on a fork of this repo with successful action.

- [:white_check_mark: :  ] Yes

## Checklist:

- [:heavy_check_mark:  ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [:heavy_check_mark: ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ :heavy_check_mark:] I have checked my code and corrected any misspellings
