### PR TITLE
Fix incorrect reuse of input solar features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ checkpoints/
 lightning_logs/
 pixi.lock
 .python-version
+.venv/

--- a/graph_weather/data/dataloader.py
+++ b/graph_weather/data/dataloader.py
@@ -117,7 +117,7 @@ class AnalysisDataset(Dataset):
             end_solar_times.append(
                 np.array([extraterrestrial_irrad(when, lat, lon) for lat, lon in lat_lons])
             )
-        end_solar_times = np.array(solar_times)
+        end_solar_times = np.array(end_solar_times)
 
         # Normalize to between -1 and 1
         solar_times -= const.SOLAR_MEAN


### PR DESCRIPTION
# Pull Request

## Description

This pull request addresses a bug in the solar irradiance computation logic within the dataloader and adds comprehensive regression tests to prevent future regressions. The main issue fixed was the incorrect assignment of the `end_solar_times` variable, which previously reused solar times from the wrong date, potentially causing data leakage and incorrect model behavior. The new tests explicitly verify that solar features are computed independently for input and target dates and that the bug does not reappear.

Bug fix in solar irradiance computation:

* Corrected assignment of `end_solar_times` in `graph_weather/data/dataloader.py` to use the properly computed list for the target date, ensuring accurate solar feature calculation and preventing temporal data leakage.

Regression and data leakage prevention tests:

* Added `tests/test_dataloader.py` containing regression tests that verify solar times are different for distinct dates and times of day, ensuring the bug does not reoccur and that input and target features remain independent.
* Included test logic that scans the dataloader source code to confirm the fixed assignment is present and the buggy pattern is absent, providing an automated safeguard against accidental reintroduction of the bug.
* Added checks to ensure solar irradiance values vary throughout the day and across different dates, further validating the correctness of feature computation.

Fixes #199

<img width="1322" height="356" alt="Screenshot from 2026-01-09 02-49-46" src="https://github.com/user-attachments/assets/26a2eb43-f868-4b0a-9239-8e95192cf119" />
