### PR TITLE
fix: migrate AssimilatorEncoder to H3 v4 API

### DIFF
--- a/graph_weather/models/layers/assimilator_encoder.py
+++ b/graph_weather/models/layers/assimilator_encoder.py
@@ -71,13 +71,13 @@ class AssimilatorEncoder(torch.nn.Module):
         self.output_dim = output_dim
         self.input_dim = input_dim
         self.resolution = resolution
-        self.base_h3_grid = sorted(list(h3.uncompact(h3.get_res0_indexes(), resolution)))
+        self.base_h3_grid = sorted(list(h3.uncompact_cells(h3.get_res0_cells(), resolution)))
         self.base_h3_map = {h_i: i for i, h_i in enumerate(self.base_h3_grid)}
         self.h3_mapping = {}
         self.latent_graph = self.create_latent_graph()
 
         # Extra starting ones for appending to inputs, could 'learn' good starting points
-        self.h3_nodes = torch.zeros((h3.num_hexagons(resolution), input_dim), dtype=torch.float)
+        self.h3_nodes = torch.zeros((h3.get_num_cells(resolution), input_dim), dtype=torch.float)
         # Output graph
 
         self.node_encoder = MLP(
@@ -180,7 +180,9 @@ class AssimilatorEncoder(torch.nn.Module):
             edge attributes for the input
         """
         num_latlons = lat_lons_heights.shape[0]
-        h3_grid = [h3.geo_to_h3(lat, lon, self.resolution) for lat, lon, height in lat_lons_heights]
+        h3_grid = [
+            h3.latlng_to_cell(lat, lon, self.resolution) for lat, lon, height in lat_lons_heights
+        ]
         h3_mapping = {}
         h_index = len(self.base_h3_grid)
         for h in self.base_h3_grid:
@@ -193,7 +195,9 @@ class AssimilatorEncoder(torch.nn.Module):
         h3_distances = []
         for idx, h3_point in enumerate(h3_grid):
             lat, lon, height = lat_lons_heights[idx]
-            distance = h3.point_dist((lat, lon), h3.h3_to_geo(h3_point), unit="rads")
+            distance = h3.great_circle_distance(
+                (lat, lon), h3.cell_to_latlng(h3_point), unit="rads"
+            )
             # TODO Normalize height by some amount
             h3_distances.append([np.sin(distance), np.cos(distance), height])
         h3_distances = torch.tensor(h3_distances, dtype=torch.float)
@@ -223,9 +227,11 @@ class AssimilatorEncoder(torch.nn.Module):
         edge_targets = []
         edge_attrs = []
         for h3_index in self.base_h3_grid:
-            h_points = h3.k_ring(h3_index, 1)
+            h_points = h3.grid_disk(h3_index, 1)
             for h in h_points:  # Already includes itself
-                distance = h3.point_dist(h3.h3_to_geo(h3_index), h3.h3_to_geo(h), unit="rads")
+                distance = h3.great_circle_distance(
+                    h3.cell_to_latlng(h3_index), h3.cell_to_latlng(h), unit="rads"
+                )
                 edge_attrs.append([np.sin(distance), np.cos(distance)])
                 edge_sources.append(self.base_h3_map[h3_index])
                 edge_targets.append(self.base_h3_map[h])

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -51,9 +51,9 @@ def test_assimilation_encoder_uneven_grid():
     lat_lons = []
     for lat in range(-90, 90, 7):
         for lon in range(0, 180, 5):
-            lat_lons.append((lat, lon, np.random.random(1)))
+            lat_lons.append((lat, lon, np.random.random()))
         for lon in range(180, 360, 9):
-            lat_lons.append((lat, lon, np.random.random(1)))
+            lat_lons.append((lat, lon, np.random.random()))
     model = AssimilatorEncoder().eval()
 
     features = torch.randn((2, len(lat_lons), 2))
@@ -85,7 +85,7 @@ def test_decoder():
             lat_lons.append((lat, lon))
     model = Decoder(lat_lons).eval()
     features = torch.randn((3, len(lat_lons), 78))
-    processed = torch.randn((3 * h3.num_hexagons(2), 256))
+    processed = torch.randn((3 * h3.get_num_cells(2), 256))
     with torch.no_grad():
         x = model(processed, features)
     assert x.size() == (3, 2592, 78)
@@ -97,7 +97,7 @@ def test_assimilator():
         for lon in range(0, 360, 5):
             lat_lons.append((lat, lon))
     model = AssimilatorDecoder(lat_lons).eval()
-    processed = torch.randn((3 * h3.num_hexagons(2), 256))
+    processed = torch.randn((3 * h3.get_num_cells(2), 256))
     with torch.no_grad():
         x = model(processed, 3)
     assert x.size() == (3, 2592, 78)
@@ -137,9 +137,9 @@ def test_assimilator_model():
     obs_lat_lons = []
     for lat in range(-90, 90, 7):
         for lon in range(0, 180, 6):
-            obs_lat_lons.append((lat, lon, np.random.random(1)))
+            obs_lat_lons.append((lat, lon, np.random.random()))
         for lon in 360 * np.random.random(100):
-            obs_lat_lons.append((lat, lon, np.random.random(1)))
+            obs_lat_lons.append((lat, lon, np.random.random()))
 
     output_lat_lons = []
     for lat in range(-90, 90, 5):
@@ -196,9 +196,9 @@ def test_assimilator_model_grad_checkpoint():
     obs_lat_lons = []
     for lat in range(-90, 90, 7):
         for lon in range(0, 180, 6):
-            obs_lat_lons.append((lat, lon, np.random.random(1)))
+            obs_lat_lons.append((lat, lon, np.random.random()))
         for lon in 360 * np.random.random(100):
-            obs_lat_lons.append((lat, lon, np.random.random(1)))
+            obs_lat_lons.append((lat, lon, np.random.random()))
 
     output_lat_lons = []
     for lat in range(-90, 90, 5):


### PR DESCRIPTION
## Problem

`AssimilatorEncoder` uses deprecated H3 v3 API calls (`geo_to_h3`, `h3_to_geo`, `point_dist`, `k_ring`, etc.), but the repo pins `h3==4.3.1`. This causes `AttributeError` on instantiation — the class is unusable under the pinned version.

The sibling classes (`Encoder`, `AssimilatorDecoder`) were already migrated to v4. This brings `AssimilatorEncoder` in line.

## Changes

**`assimilator_encoder.py`** — 6 mechanical name substitutions:
- `h3.uncompact(h3.get_res0_indexes(), ...)` → `h3.uncompact_cells(h3.get_res0_cells(), ...)`
- `h3.num_hexagons()` → `h3.get_num_cells()`
- `h3.geo_to_h3()` → `h3.latlng_to_cell()`
- `h3.h3_to_geo()` → `h3.cell_to_latlng()`
- `h3.point_dist()` → `h3.great_circle_distance()`
- `h3.k_ring()` → `h3.grid_disk()`

**`tests/test_model.py`**:
- 2x `h3.num_hexagons` → `h3.get_num_cells` (same migration)
- 5x `np.random.random(1)` → `np.random.random()` (fixes numpy 2.x incompatibility that was hidden behind the H3 crash)

## Testing

- `test_assimilation_encoder_uneven_grid`: was crashing with `AttributeError`, now passes
- `test_assimilator_model`, `test_assimilator_model_grad_checkpoint`: same, now pass
- All 14 previously-passing tests remain green (19/21 total, 2 unrelated `torch-cluster` failures unchanged)
