### PR TITLE
feat: add DynamicGraphBuilder for runtime bipartite graph construction

### DIFF
--- a/graph_weather/models/layers/dynamic_graph_builder.py
+++ b/graph_weather/models/layers/dynamic_graph_builder.py
@@ -1,16 +1,4 @@
-"""Dynamic bipartite graph construction for regional weather models.
-
-Builds lat/lon ↔ H3 bipartite graphs at call time, enabling the
-high-resolution region to move per batch without re-instantiating
-the model. Replaces the static graph construction in Encoder.__init__
-and AssimilatorDecoder.__init__ with a callable that rebuilds when
-coordinates change.
-
-Reference:
-    Encoder static construction: graph_weather/models/layers/encoder.py
-    Decoder static construction: graph_weather/models/layers/assimilator_decoder.py
-    Formal spec: .kiro/specs/movable-regional-prototype/requirements.md (Req 1, 2, 7)
-"""
+"""Dynamic H3 graph construction from latitude and longitude coordinates."""
 
 from typing import List, Optional, Tuple
 
@@ -19,24 +7,18 @@ import numpy as np
 import torch
 from torch_geometric.data import Data
 
+from graph_weather.utils import validate_lat_lons
+
 
 class DynamicGraphBuilder:
-    """Builds bipartite and latent graphs from arbitrary lat/lon coordinates.
-
-    Unlike the static graph baked in Encoder.__init__, this class constructs
-    graphs at call time. When the same coordinate list object is passed again,
-    it returns the previously built graphs without rebuilding (Req 1.4).
-
-    The encoder graph uses 1-to-1 edges (each lat/lon → its H3 cell).
-    The decoder graph uses 1-to-many edges (each lat/lon → ring-1 neighborhood).
-    The latent graph connects only the H3 cells used by the regional coordinates.
+    """Build encoder, decoder, and latent graphs from lat/lon coordinates.
 
     Args:
         resolution: H3 resolution level for the latent mesh.
     """
 
     def __init__(self, resolution: int = 2):
-        """Initialize with the given H3 resolution level."""
+        """Initialize the builder."""
         self.resolution = resolution
         self._prev_lat_lons: Optional[List[Tuple[float, float]]] = None
         self._cached_encoder_graph: Optional[Data] = None
@@ -44,51 +26,21 @@ class DynamicGraphBuilder:
         self._cached_latent_graph: Optional[Data] = None
         self._cached_h3_indices: Optional[List[int]] = None
 
-    def _validate(self, lat_lons: List[Tuple[float, float]]) -> None:
-        """Validate coordinate list. Raises ValueError on bad input."""
-        if not lat_lons:
-            raise ValueError(
-                "lat_lons must not be empty. Provide at least one coordinate."
-            )
-        for i, (lat, lon) in enumerate(lat_lons):
-            if not (-90.0 <= lat <= 90.0):
-                raise ValueError(
-                    f"Coordinate {i}: latitude {lat} is outside [-90, 90]."
-                )
-
     def _assign_h3_cells(
         self, lat_lons: List[Tuple[float, float]]
     ) -> Tuple[List[str], List[str], dict]:
-        """Map each coordinate to an H3 cell and build index mappings.
-
-        Returns:
-            h3_cells: H3 cell ID per coordinate (same order as lat_lons).
-            unique_cells: Sorted list of unique H3 cell IDs.
-            cell_to_idx: Mapping from H3 cell ID to integer index.
-        """
-        h3_cells = [
-            h3.latlng_to_cell(lat, lon, self.resolution)
-            for lat, lon in lat_lons
-        ]
+        """Map each coordinate to its H3 cell and return index mappings."""
+        h3_cells = [h3.latlng_to_cell(lat, lon, self.resolution) for lat, lon in lat_lons]
         unique_cells = sorted(set(h3_cells))
         cell_to_idx = {cell: i for i, cell in enumerate(unique_cells)}
         return h3_cells, unique_cells, cell_to_idx
 
-    def build_encoder_graph(
-        self, lat_lons: List[Tuple[float, float]]
-    ) -> Tuple[Data, List[int]]:
-        """Build the lat/lon → H3 bipartite graph for encoding.
-
-        Each lat/lon node gets exactly one edge to its assigned H3 cell.
-        Edge attributes are [sin(d), cos(d)] where d is the great-circle
-        distance in radians, matching encoder.py lines 87-92.
-
-        Args:
-            lat_lons: Regional coordinates as (lat, lon) pairs.
+    def build_encoder_graph(self, lat_lons: List[Tuple[float, float]]) -> Tuple[Data, List[int]]:
+        """Build 1-to-1 edges from lat/lon nodes to H3 cells.
 
         Returns:
             graph: Data with edge_index [2, N] and edge_attr [N, 2].
-            h3_indices: Sorted unique H3 cell indices for embedding lookup.
+            h3_indices: Global H3 cell indices for embedding lookup.
         """
         h3_cells, unique_cells, cell_to_idx = self._assign_h3_cells(lat_lons)
         num_coords = len(lat_lons)
@@ -100,51 +52,31 @@ class DynamicGraphBuilder:
         for node_idx, (coord, cell) in enumerate(zip(lat_lons, h3_cells)):
             edge_sources.append(node_idx)
             edge_targets.append(num_coords + cell_to_idx[cell])
-            dist = h3.great_circle_distance(
-                coord, h3.cell_to_latlng(cell), unit="rads"
-            )
+            dist = h3.great_circle_distance(coord, h3.cell_to_latlng(cell), unit="rads")
             edge_attrs.append([np.sin(dist), np.cos(dist)])
 
-        edge_index = torch.tensor(
-            [edge_sources, edge_targets], dtype=torch.long
-        )
+        edge_index = torch.tensor([edge_sources, edge_targets], dtype=torch.long)
         edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
 
-        # Map unique H3 cells to global indices for embedding table lookup
-        all_h3 = sorted(
-            h3.uncompact_cells(h3.get_res0_cells(), self.resolution)
-        )
+        all_h3 = sorted(h3.uncompact_cells(h3.get_res0_cells(), self.resolution))
         global_h3_map = {cell: i for i, cell in enumerate(all_h3)}
         h3_indices = [global_h3_map[cell] for cell in unique_cells]
 
         return Data(edge_index=edge_index, edge_attr=edge_attr), h3_indices
 
-    def build_decoder_graph(
-        self, lat_lons: List[Tuple[float, float]]
-    ) -> Data:
-        """Build the H3 → lat/lon bipartite graph for decoding.
-
-        Each lat/lon node connects to its assigned H3 cell AND its
-        ring-1 neighbors (~7 edges per node). This richer connectivity
-        enables interpolation back to arbitrary positions, matching
-        assimilator_decoder.py lines 92-101.
-
-        Args:
-            lat_lons: Regional coordinates as (lat, lon) pairs.
+    def build_decoder_graph(self, lat_lons: List[Tuple[float, float]]) -> Data:
+        """Build edges from H3 cells to lat/lon nodes.
 
         Returns:
             Data with edge_index [2, E] and edge_attr [E, 2].
         """
-        h3_cells, unique_cells, cell_to_idx = self._assign_h3_cells(lat_lons)
+        h3_cells, unique_cells, _ = self._assign_h3_cells(lat_lons)
 
-        # Build a mapping that includes ring-1 neighbors of all assigned cells
         all_neighborhood_cells = set()
         for cell in unique_cells:
             all_neighborhood_cells.update(h3.grid_disk(cell, 1))
         all_neighborhood_cells = sorted(all_neighborhood_cells)
-        neighborhood_to_idx = {
-            cell: i for i, cell in enumerate(all_neighborhood_cells)
-        }
+        neighborhood_to_idx = {cell: i for i, cell in enumerate(all_neighborhood_cells)}
 
         edge_sources = []
         edge_targets = []
@@ -156,26 +88,15 @@ class DynamicGraphBuilder:
                 h_idx = neighborhood_to_idx[h]
                 edge_sources.append(h_idx)
                 edge_targets.append(len(all_neighborhood_cells) + node_idx)
-                dist = h3.great_circle_distance(
-                    coord, h3.cell_to_latlng(h), unit="rads"
-                )
+                dist = h3.great_circle_distance(coord, h3.cell_to_latlng(h), unit="rads")
                 edge_attrs.append([np.sin(dist), np.cos(dist)])
 
-        edge_index = torch.tensor(
-            [edge_sources, edge_targets], dtype=torch.long
-        )
+        edge_index = torch.tensor([edge_sources, edge_targets], dtype=torch.long)
         edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
         return Data(edge_index=edge_index, edge_attr=edge_attr)
 
     def build_latent_graph(self, unique_cells: List[str]) -> Data:
-        """Build the H3 ↔ H3 neighbor connectivity for message passing.
-
-        Only connects H3 cells that the regional coordinates map to,
-        NOT the full global mesh. Each cell connects to its ring-1
-        neighbors (itself + 6 neighbors), matching encoder.py lines 244-268.
-
-        Args:
-            unique_cells: Sorted unique H3 cell IDs from the regional coords.
+        """Build H3 neighbor edges for the supplied cells.
 
         Returns:
             Data with edge_index [2, E] and edge_attr [E, 2].
@@ -200,25 +121,15 @@ class DynamicGraphBuilder:
                 edge_targets.append(cell_to_idx[h])
                 edge_attrs.append([np.sin(dist), np.cos(dist)])
 
-        edge_index = torch.tensor(
-            [edge_sources, edge_targets], dtype=torch.long
-        )
+        edge_index = torch.tensor([edge_sources, edge_targets], dtype=torch.long)
         edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
         return Data(edge_index=edge_index, edge_attr=edge_attr)
 
-    def __call__(
-        self, lat_lons: List[Tuple[float, float]]
-    ) -> Tuple[Data, Data, Data, List[int]]:
+    def __call__(self, lat_lons: List[Tuple[float, float]]) -> Tuple[Data, Data, Data, List[int]]:
         """Build or return cached encoder, decoder, and latent graphs.
 
-        Args:
-            lat_lons: Regional coordinates as (lat, lon) pairs.
-
         Returns:
-            encoder_graph: Bipartite lat/lon → H3 (1-to-1 edges).
-            decoder_graph: Bipartite H3 → lat/lon (ring-1 edges).
-            latent_graph: H3 ↔ H3 regional mesh connectivity.
-            h3_indices: Global H3 cell indices for embedding lookup.
+            Tuple of (encoder_graph, decoder_graph, latent_graph, h3_indices).
         """
         if lat_lons is self._prev_lat_lons:
             return (
@@ -228,7 +139,7 @@ class DynamicGraphBuilder:
                 self._cached_h3_indices,
             )
 
-        self._validate(lat_lons)
+        validate_lat_lons(lat_lons)
 
         encoder_graph, h3_indices = self.build_encoder_graph(lat_lons)
         _, unique_cells, _ = self._assign_h3_cells(lat_lons)

--- a/graph_weather/models/layers/dynamic_graph_builder.py
+++ b/graph_weather/models/layers/dynamic_graph_builder.py
@@ -20,6 +20,8 @@ class DynamicGraphBuilder:
     def __init__(self, resolution: int = 2):
         """Initialize the builder."""
         self.resolution = resolution
+        self.all_h3 = sorted(h3.uncompact_cells(h3.get_res0_cells(), self.resolution))
+        self.global_h3_map = {cell: i for i, cell in enumerate(self.all_h3)}
         self._prev_lat_lons: Optional[List[Tuple[float, float]]] = None
         self._cached_encoder_graph: Optional[Data] = None
         self._cached_decoder_graph: Optional[Data] = None
@@ -58,9 +60,7 @@ class DynamicGraphBuilder:
         edge_index = torch.tensor([edge_sources, edge_targets], dtype=torch.long)
         edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
 
-        all_h3 = sorted(h3.uncompact_cells(h3.get_res0_cells(), self.resolution))
-        global_h3_map = {cell: i for i, cell in enumerate(all_h3)}
-        h3_indices = [global_h3_map[cell] for cell in unique_cells]
+        h3_indices = [self.global_h3_map[cell] for cell in unique_cells]
 
         return Data(edge_index=edge_index, edge_attr=edge_attr), h3_indices
 

--- a/graph_weather/models/layers/dynamic_graph_builder.py
+++ b/graph_weather/models/layers/dynamic_graph_builder.py
@@ -1,0 +1,244 @@
+"""Dynamic bipartite graph construction for regional weather models.
+
+Builds lat/lon ↔ H3 bipartite graphs at call time, enabling the
+high-resolution region to move per batch without re-instantiating
+the model. Replaces the static graph construction in Encoder.__init__
+and AssimilatorDecoder.__init__ with a callable that rebuilds when
+coordinates change.
+
+Reference:
+    Encoder static construction: graph_weather/models/layers/encoder.py
+    Decoder static construction: graph_weather/models/layers/assimilator_decoder.py
+    Formal spec: .kiro/specs/movable-regional-prototype/requirements.md (Req 1, 2, 7)
+"""
+
+from typing import List, Optional, Tuple
+
+import h3
+import numpy as np
+import torch
+from torch_geometric.data import Data
+
+
+class DynamicGraphBuilder:
+    """Builds bipartite and latent graphs from arbitrary lat/lon coordinates.
+
+    Unlike the static graph baked in Encoder.__init__, this class constructs
+    graphs at call time. When the same coordinate list object is passed again,
+    it returns the previously built graphs without rebuilding (Req 1.4).
+
+    The encoder graph uses 1-to-1 edges (each lat/lon → its H3 cell).
+    The decoder graph uses 1-to-many edges (each lat/lon → ring-1 neighborhood).
+    The latent graph connects only the H3 cells used by the regional coordinates.
+
+    Args:
+        resolution: H3 resolution level for the latent mesh.
+    """
+
+    def __init__(self, resolution: int = 2):
+        """Initialize with the given H3 resolution level."""
+        self.resolution = resolution
+        self._prev_lat_lons: Optional[List[Tuple[float, float]]] = None
+        self._cached_encoder_graph: Optional[Data] = None
+        self._cached_decoder_graph: Optional[Data] = None
+        self._cached_latent_graph: Optional[Data] = None
+        self._cached_h3_indices: Optional[List[int]] = None
+
+    def _validate(self, lat_lons: List[Tuple[float, float]]) -> None:
+        """Validate coordinate list. Raises ValueError on bad input."""
+        if not lat_lons:
+            raise ValueError(
+                "lat_lons must not be empty. Provide at least one coordinate."
+            )
+        for i, (lat, lon) in enumerate(lat_lons):
+            if not (-90.0 <= lat <= 90.0):
+                raise ValueError(
+                    f"Coordinate {i}: latitude {lat} is outside [-90, 90]."
+                )
+
+    def _assign_h3_cells(
+        self, lat_lons: List[Tuple[float, float]]
+    ) -> Tuple[List[str], List[str], dict]:
+        """Map each coordinate to an H3 cell and build index mappings.
+
+        Returns:
+            h3_cells: H3 cell ID per coordinate (same order as lat_lons).
+            unique_cells: Sorted list of unique H3 cell IDs.
+            cell_to_idx: Mapping from H3 cell ID to integer index.
+        """
+        h3_cells = [
+            h3.latlng_to_cell(lat, lon, self.resolution)
+            for lat, lon in lat_lons
+        ]
+        unique_cells = sorted(set(h3_cells))
+        cell_to_idx = {cell: i for i, cell in enumerate(unique_cells)}
+        return h3_cells, unique_cells, cell_to_idx
+
+    def build_encoder_graph(
+        self, lat_lons: List[Tuple[float, float]]
+    ) -> Tuple[Data, List[int]]:
+        """Build the lat/lon → H3 bipartite graph for encoding.
+
+        Each lat/lon node gets exactly one edge to its assigned H3 cell.
+        Edge attributes are [sin(d), cos(d)] where d is the great-circle
+        distance in radians, matching encoder.py lines 87-92.
+
+        Args:
+            lat_lons: Regional coordinates as (lat, lon) pairs.
+
+        Returns:
+            graph: Data with edge_index [2, N] and edge_attr [N, 2].
+            h3_indices: Sorted unique H3 cell indices for embedding lookup.
+        """
+        h3_cells, unique_cells, cell_to_idx = self._assign_h3_cells(lat_lons)
+        num_coords = len(lat_lons)
+
+        edge_sources = []
+        edge_targets = []
+        edge_attrs = []
+
+        for node_idx, (coord, cell) in enumerate(zip(lat_lons, h3_cells)):
+            edge_sources.append(node_idx)
+            edge_targets.append(num_coords + cell_to_idx[cell])
+            dist = h3.great_circle_distance(
+                coord, h3.cell_to_latlng(cell), unit="rads"
+            )
+            edge_attrs.append([np.sin(dist), np.cos(dist)])
+
+        edge_index = torch.tensor(
+            [edge_sources, edge_targets], dtype=torch.long
+        )
+        edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
+
+        # Map unique H3 cells to global indices for embedding table lookup
+        all_h3 = sorted(
+            h3.uncompact_cells(h3.get_res0_cells(), self.resolution)
+        )
+        global_h3_map = {cell: i for i, cell in enumerate(all_h3)}
+        h3_indices = [global_h3_map[cell] for cell in unique_cells]
+
+        return Data(edge_index=edge_index, edge_attr=edge_attr), h3_indices
+
+    def build_decoder_graph(
+        self, lat_lons: List[Tuple[float, float]]
+    ) -> Data:
+        """Build the H3 → lat/lon bipartite graph for decoding.
+
+        Each lat/lon node connects to its assigned H3 cell AND its
+        ring-1 neighbors (~7 edges per node). This richer connectivity
+        enables interpolation back to arbitrary positions, matching
+        assimilator_decoder.py lines 92-101.
+
+        Args:
+            lat_lons: Regional coordinates as (lat, lon) pairs.
+
+        Returns:
+            Data with edge_index [2, E] and edge_attr [E, 2].
+        """
+        h3_cells, unique_cells, cell_to_idx = self._assign_h3_cells(lat_lons)
+
+        # Build a mapping that includes ring-1 neighbors of all assigned cells
+        all_neighborhood_cells = set()
+        for cell in unique_cells:
+            all_neighborhood_cells.update(h3.grid_disk(cell, 1))
+        all_neighborhood_cells = sorted(all_neighborhood_cells)
+        neighborhood_to_idx = {
+            cell: i for i, cell in enumerate(all_neighborhood_cells)
+        }
+
+        edge_sources = []
+        edge_targets = []
+        edge_attrs = []
+
+        for node_idx, (coord, cell) in enumerate(zip(lat_lons, h3_cells)):
+            neighbors = h3.grid_disk(cell, 1)
+            for h in neighbors:
+                h_idx = neighborhood_to_idx[h]
+                edge_sources.append(h_idx)
+                edge_targets.append(len(all_neighborhood_cells) + node_idx)
+                dist = h3.great_circle_distance(
+                    coord, h3.cell_to_latlng(h), unit="rads"
+                )
+                edge_attrs.append([np.sin(dist), np.cos(dist)])
+
+        edge_index = torch.tensor(
+            [edge_sources, edge_targets], dtype=torch.long
+        )
+        edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
+        return Data(edge_index=edge_index, edge_attr=edge_attr)
+
+    def build_latent_graph(self, unique_cells: List[str]) -> Data:
+        """Build the H3 ↔ H3 neighbor connectivity for message passing.
+
+        Only connects H3 cells that the regional coordinates map to,
+        NOT the full global mesh. Each cell connects to its ring-1
+        neighbors (itself + 6 neighbors), matching encoder.py lines 244-268.
+
+        Args:
+            unique_cells: Sorted unique H3 cell IDs from the regional coords.
+
+        Returns:
+            Data with edge_index [2, E] and edge_attr [E, 2].
+        """
+        cell_to_idx = {cell: i for i, cell in enumerate(unique_cells)}
+
+        edge_sources = []
+        edge_targets = []
+        edge_attrs = []
+
+        for cell in unique_cells:
+            neighbors = h3.grid_disk(cell, 1)
+            for h in neighbors:
+                if h not in cell_to_idx:
+                    continue
+                dist = h3.great_circle_distance(
+                    h3.cell_to_latlng(cell),
+                    h3.cell_to_latlng(h),
+                    unit="rads",
+                )
+                edge_sources.append(cell_to_idx[cell])
+                edge_targets.append(cell_to_idx[h])
+                edge_attrs.append([np.sin(dist), np.cos(dist)])
+
+        edge_index = torch.tensor(
+            [edge_sources, edge_targets], dtype=torch.long
+        )
+        edge_attr = torch.tensor(edge_attrs, dtype=torch.float)
+        return Data(edge_index=edge_index, edge_attr=edge_attr)
+
+    def __call__(
+        self, lat_lons: List[Tuple[float, float]]
+    ) -> Tuple[Data, Data, Data, List[int]]:
+        """Build or return cached encoder, decoder, and latent graphs.
+
+        Args:
+            lat_lons: Regional coordinates as (lat, lon) pairs.
+
+        Returns:
+            encoder_graph: Bipartite lat/lon → H3 (1-to-1 edges).
+            decoder_graph: Bipartite H3 → lat/lon (ring-1 edges).
+            latent_graph: H3 ↔ H3 regional mesh connectivity.
+            h3_indices: Global H3 cell indices for embedding lookup.
+        """
+        if lat_lons is self._prev_lat_lons:
+            return (
+                self._cached_encoder_graph,
+                self._cached_decoder_graph,
+                self._cached_latent_graph,
+                self._cached_h3_indices,
+            )
+
+        self._validate(lat_lons)
+
+        encoder_graph, h3_indices = self.build_encoder_graph(lat_lons)
+        _, unique_cells, _ = self._assign_h3_cells(lat_lons)
+        decoder_graph = self.build_decoder_graph(lat_lons)
+        latent_graph = self.build_latent_graph(unique_cells)
+
+        self._prev_lat_lons = lat_lons
+        self._cached_encoder_graph = encoder_graph
+        self._cached_decoder_graph = decoder_graph
+        self._cached_latent_graph = latent_graph
+        self._cached_h3_indices = h3_indices
+
+        return encoder_graph, decoder_graph, latent_graph, h3_indices

--- a/graph_weather/utils.py
+++ b/graph_weather/utils.py
@@ -1,0 +1,12 @@
+"""Shared utility functions for graph weather models."""
+
+from typing import Sequence, Tuple
+
+
+def validate_lat_lons(lat_lons: Sequence[Tuple[float, float]]) -> None:
+    """Validate a non-empty sequence of latitude and longitude pairs."""
+    if not lat_lons:
+        raise ValueError("lat_lons must not be empty.")
+    for index, (lat, _lon) in enumerate(lat_lons):
+        if not (-90.0 <= lat <= 90.0):
+            raise ValueError(f"Coordinate {index}: latitude {lat} is outside [-90, 90].")

--- a/tests/test_dynamic_graph_builder.py
+++ b/tests/test_dynamic_graph_builder.py
@@ -1,25 +1,14 @@
-"""Tests for DynamicGraphBuilder.
-
-Covers graph construction, caching, validation, and the encoder/decoder
-topology asymmetry. Uses synthetic coordinates matching the patterns in
-tests/test_model.py.
-"""
-
+import h3
 import pytest
 import torch
 from torch_geometric.data import Data
 
 from graph_weather.models.layers.dynamic_graph_builder import DynamicGraphBuilder
+from graph_weather.utils import validate_lat_lons
 
 
-@pytest.fixture
-def builder():
-    return DynamicGraphBuilder(resolution=2)
-
-
-@pytest.fixture
-def small_region():
-    """A small 5x5 lat/lon patch centered on London."""
+def _small_region():
+    """5x5 lat/lon patch around London."""
     lat_lons = []
     for lat in range(50, 55):
         for lon in range(-2, 3):
@@ -27,136 +16,157 @@ def small_region():
     return lat_lons
 
 
-class TestEncoderGraph:
-    def test_shape(self, builder, small_region):
-        graph, h3_indices = builder.build_encoder_graph(small_region)
-        assert graph.edge_index.shape[0] == 2
-        assert graph.edge_index.dtype == torch.long
-        assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
-        assert graph.edge_attr.shape[1] == 2
-
-    def test_one_edge_per_node(self, builder, small_region):
-        graph, _ = builder.build_encoder_graph(small_region)
-        assert graph.edge_index.shape[1] == len(small_region)
-
-    def test_h3_indices_returned(self, builder, small_region):
-        _, h3_indices = builder.build_encoder_graph(small_region)
-        assert len(h3_indices) > 0
-        assert all(isinstance(i, int) for i in h3_indices)
-        # Must be fewer unique H3 cells than coordinates
-        assert len(h3_indices) <= len(small_region)
+def test_encoder_graph_shape():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    graph, h3_indices = builder.build_encoder_graph(lat_lons)
+    assert graph.edge_index.shape[0] == 2
+    assert graph.edge_index.dtype == torch.long
+    assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
+    assert graph.edge_attr.shape[1] == 2
 
 
-class TestDecoderGraph:
-    def test_more_edges_than_encoder(self, builder, small_region):
-        enc_graph, _ = builder.build_encoder_graph(small_region)
-        dec_graph = builder.build_decoder_graph(small_region)
-        # Decoder uses ring-1 neighborhood: ~7 edges per node vs 1
-        assert dec_graph.edge_index.shape[1] > enc_graph.edge_index.shape[1]
-
-    def test_shape(self, builder, small_region):
-        graph = builder.build_decoder_graph(small_region)
-        assert graph.edge_index.shape[0] == 2
-        assert graph.edge_index.dtype == torch.long
-        assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
-        assert graph.edge_attr.shape[1] == 2
+def test_encoder_one_edge_per_node():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    graph, _ = builder.build_encoder_graph(lat_lons)
+    assert graph.edge_index.shape[1] == len(lat_lons)
 
 
-class TestLatentGraph:
-    def test_scoped_to_region(self, builder, small_region):
-        """Latent graph has far fewer nodes than the full global mesh."""
-        import h3 as h3_lib
-
-        h3_cells = [
-            h3_lib.latlng_to_cell(lat, lon, builder.resolution)
-            for lat, lon in small_region
-        ]
-        unique_cells = sorted(set(h3_cells))
-        graph = builder.build_latent_graph(unique_cells)
-
-        total_global = h3_lib.get_num_cells(builder.resolution)
-        # The latent graph node count (derived from unique_cells) is much
-        # smaller than the full global mesh
-        assert len(unique_cells) < total_global
-        assert graph.edge_index.shape[0] == 2
-        assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
-
-    def test_self_loops_present(self, builder, small_region):
-        """grid_disk(cell, 1) includes the cell itself, so self-loops exist."""
-        import h3 as h3_lib
-
-        h3_cells = [
-            h3_lib.latlng_to_cell(lat, lon, builder.resolution)
-            for lat, lon in small_region
-        ]
-        unique_cells = sorted(set(h3_cells))
-        graph = builder.build_latent_graph(unique_cells)
-
-        src, dst = graph.edge_index[0], graph.edge_index[1]
-        self_loops = (src == dst).sum().item()
-        assert self_loops == len(unique_cells)
+def test_encoder_h3_indices():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    _, h3_indices = builder.build_encoder_graph(lat_lons)
+    assert len(h3_indices) > 0
+    assert all(isinstance(i, int) for i in h3_indices)
+    assert len(h3_indices) <= len(lat_lons)
 
 
-class TestCaching:
-    def test_same_object_returns_cached(self, builder, small_region):
-        result1 = builder(small_region)
-        result2 = builder(small_region)
-        # Same list object → same graph objects (identity check)
-        assert result1[0] is result2[0]
-        assert result1[1] is result2[1]
-        assert result1[2] is result2[2]
-
-    def test_different_coords_rebuild(self, builder, small_region):
-        result1 = builder(small_region)
-        different_region = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]
-        result2 = builder(different_region)
-        assert result1[0] is not result2[0]
+def test_decoder_more_edges_than_encoder():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    enc_graph, _ = builder.build_encoder_graph(lat_lons)
+    dec_graph = builder.build_decoder_graph(lat_lons)
+    assert dec_graph.edge_index.shape[1] > enc_graph.edge_index.shape[1]
 
 
-class TestValidation:
-    def test_empty_list_raises(self, builder):
-        with pytest.raises(ValueError, match="must not be empty"):
-            builder([])
-
-    def test_invalid_latitude_raises(self, builder):
-        with pytest.raises(ValueError, match="latitude"):
-            builder([(91.0, 0.0)])
-
-    def test_negative_invalid_latitude_raises(self, builder):
-        with pytest.raises(ValueError, match="latitude"):
-            builder([(-91.0, 0.0)])
-
-    def test_valid_boundary_latitudes(self, builder):
-        """Latitudes exactly at -90 and 90 should work."""
-        result = builder([(-90.0, 0.0), (90.0, 180.0)])
-        assert result[0].edge_index.shape[1] == 2
+def test_decoder_graph_shape():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    graph = builder.build_decoder_graph(lat_lons)
+    assert graph.edge_index.shape[0] == 2
+    assert graph.edge_index.dtype == torch.long
+    assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
+    assert graph.edge_attr.shape[1] == 2
 
 
-class TestEdgeAttributes:
-    def test_edge_attr_matches_edge_count(self, builder, small_region):
-        enc, _ = builder.build_encoder_graph(small_region)
-        dec = builder.build_decoder_graph(small_region)
-        assert enc.edge_attr.shape[0] == enc.edge_index.shape[1]
-        assert dec.edge_attr.shape[0] == dec.edge_index.shape[1]
+def test_latent_graph_scoped_to_region():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    h3_cells = [h3.latlng_to_cell(lat, lon, 2) for lat, lon in lat_lons]
+    unique_cells = sorted(set(h3_cells))
+    graph = builder.build_latent_graph(unique_cells)
 
-    def test_edge_attr_values_bounded(self, builder, small_region):
-        """sin/cos values are always in [-1, 1]."""
-        enc, _ = builder.build_encoder_graph(small_region)
-        assert enc.edge_attr.abs().max() <= 1.0
+    total_global = h3.get_num_cells(2)
+    assert len(unique_cells) < total_global
+    assert graph.edge_index.shape[0] == 2
+    assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
 
 
-class TestCallInterface:
-    def test_returns_four_items(self, builder, small_region):
-        result = builder(small_region)
-        assert len(result) == 4
-        enc_graph, dec_graph, lat_graph, h3_indices = result
-        assert isinstance(enc_graph, Data)
-        assert isinstance(dec_graph, Data)
-        assert isinstance(lat_graph, Data)
-        assert isinstance(h3_indices, list)
+def test_latent_graph_self_loops():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    h3_cells = [h3.latlng_to_cell(lat, lon, 2) for lat, lon in lat_lons]
+    unique_cells = sorted(set(h3_cells))
+    graph = builder.build_latent_graph(unique_cells)
 
-    def test_round_trip_ordering(self, builder, small_region):
-        """Encoder source nodes should be ordered 0..N-1 matching input."""
-        enc_graph, _, _, _ = builder(small_region)
-        sources = enc_graph.edge_index[0].tolist()
-        assert sources == list(range(len(small_region)))
+    src, dst = graph.edge_index[0], graph.edge_index[1]
+    self_loops = (src == dst).sum().item()
+    assert self_loops == len(unique_cells)
+
+
+def test_caching_same_object():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    result1 = builder(lat_lons)
+    result2 = builder(lat_lons)
+    assert result1[0] is result2[0]
+    assert result1[1] is result2[1]
+    assert result1[2] is result2[2]
+
+
+def test_caching_different_coords_rebuild():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    result1 = builder(lat_lons)
+    different = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]
+    result2 = builder(different)
+    assert result1[0] is not result2[0]
+
+
+def test_empty_list_raises():
+    builder = DynamicGraphBuilder(resolution=2)
+    with pytest.raises(ValueError, match="must not be empty"):
+        builder([])
+
+
+def test_invalid_latitude_raises():
+    builder = DynamicGraphBuilder(resolution=2)
+    with pytest.raises(ValueError, match="latitude"):
+        builder([(91.0, 0.0)])
+
+
+def test_negative_invalid_latitude_raises():
+    builder = DynamicGraphBuilder(resolution=2)
+    with pytest.raises(ValueError, match="latitude"):
+        builder([(-91.0, 0.0)])
+
+
+def test_valid_boundary_latitudes():
+    builder = DynamicGraphBuilder(resolution=2)
+    result = builder([(-90.0, 0.0), (90.0, 180.0)])
+    assert result[0].edge_index.shape[1] == 2
+
+
+def test_edge_attr_matches_edge_count():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    enc, _ = builder.build_encoder_graph(lat_lons)
+    dec = builder.build_decoder_graph(lat_lons)
+    assert enc.edge_attr.shape[0] == enc.edge_index.shape[1]
+    assert dec.edge_attr.shape[0] == dec.edge_index.shape[1]
+
+
+def test_edge_attr_values_bounded():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    enc, _ = builder.build_encoder_graph(lat_lons)
+    assert enc.edge_attr.abs().max() <= 1.0
+
+
+def test_call_returns_four_items():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    result = builder(lat_lons)
+    assert len(result) == 4
+    enc_graph, dec_graph, lat_graph, h3_indices = result
+    assert isinstance(enc_graph, Data)
+    assert isinstance(dec_graph, Data)
+    assert isinstance(lat_graph, Data)
+    assert isinstance(h3_indices, list)
+
+
+def test_encoder_source_ordering():
+    builder = DynamicGraphBuilder(resolution=2)
+    lat_lons = _small_region()
+    enc_graph, _, _, _ = builder(lat_lons)
+    sources = enc_graph.edge_index[0].tolist()
+    assert sources == list(range(len(lat_lons)))
+
+
+def test_validate_lat_lons_standalone():
+    with pytest.raises(ValueError, match="must not be empty"):
+        validate_lat_lons([])
+    with pytest.raises(ValueError, match="latitude"):
+        validate_lat_lons([(91.0, 0.0)])
+    validate_lat_lons([(0.0, 0.0), (45.0, 90.0)])

--- a/tests/test_dynamic_graph_builder.py
+++ b/tests/test_dynamic_graph_builder.py
@@ -1,14 +1,15 @@
+"""Tests for dynamic H3 graph construction."""
+
 import h3
 import pytest
 import torch
-from torch_geometric.data import Data
 
 from graph_weather.models.layers.dynamic_graph_builder import DynamicGraphBuilder
 from graph_weather.utils import validate_lat_lons
 
 
 def _small_region():
-    """5x5 lat/lon patch around London."""
+    """Create a small set of lat/lon coordinates in a bounding box."""
     lat_lons = []
     for lat in range(50, 55):
         for lon in range(-2, 3):
@@ -16,155 +17,91 @@ def _small_region():
     return lat_lons
 
 
-def test_encoder_graph_shape():
+def test_encoder_graph():
+    """Test encoder graph shape and attributes."""
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
     graph, h3_indices = builder.build_encoder_graph(lat_lons)
-    assert graph.edge_index.shape[0] == 2
+    
+    assert graph.edge_index.shape == (2, 25)
     assert graph.edge_index.dtype == torch.long
-    assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
-    assert graph.edge_attr.shape[1] == 2
+    assert graph.edge_index[0].tolist() == list(range(25))
+    assert graph.edge_index[1].min().item() >= 25
+    assert graph.edge_attr.shape == (25, 2)
+    assert graph.edge_attr.abs().max() <= 1.0
+    
+    total_h3 = h3.get_num_cells(2)
+    assert all(0 <= idx < total_h3 for idx in h3_indices)
 
 
-def test_encoder_one_edge_per_node():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    graph, _ = builder.build_encoder_graph(lat_lons)
-    assert graph.edge_index.shape[1] == len(lat_lons)
-
-
-def test_encoder_h3_indices():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    _, h3_indices = builder.build_encoder_graph(lat_lons)
-    assert len(h3_indices) > 0
-    assert all(isinstance(i, int) for i in h3_indices)
-    assert len(h3_indices) <= len(lat_lons)
-
-
-def test_decoder_more_edges_than_encoder():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    enc_graph, _ = builder.build_encoder_graph(lat_lons)
-    dec_graph = builder.build_decoder_graph(lat_lons)
-    assert dec_graph.edge_index.shape[1] > enc_graph.edge_index.shape[1]
-
-
-def test_decoder_graph_shape():
+def test_decoder_graph():
+    """Test decoder graph shape and attributes."""
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
     graph = builder.build_decoder_graph(lat_lons)
-    assert graph.edge_index.shape[0] == 2
+    
+    assert graph.edge_index.shape == (2, 175)
     assert graph.edge_index.dtype == torch.long
-    assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
-    assert graph.edge_attr.shape[1] == 2
+    assert graph.edge_attr.shape == (175, 2)
+    assert graph.edge_attr.abs().max() <= 1.0
 
 
-def test_latent_graph_scoped_to_region():
+def test_latent_graph():
+    """Test latent graph shape and self-loops."""
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
     h3_cells = [h3.latlng_to_cell(lat, lon, 2) for lat, lon in lat_lons]
     unique_cells = sorted(set(h3_cells))
+    
+    assert len(unique_cells) == 5
+    
     graph = builder.build_latent_graph(unique_cells)
-
-    total_global = h3.get_num_cells(2)
-    assert len(unique_cells) < total_global
-    assert graph.edge_index.shape[0] == 2
-    assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
-
-
-def test_latent_graph_self_loops():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    h3_cells = [h3.latlng_to_cell(lat, lon, 2) for lat, lon in lat_lons]
-    unique_cells = sorted(set(h3_cells))
-    graph = builder.build_latent_graph(unique_cells)
-
+    
+    assert graph.edge_index.shape == (2, 19)
+    assert graph.edge_attr.shape == (19, 2)
+    
     src, dst = graph.edge_index[0], graph.edge_index[1]
     self_loops = (src == dst).sum().item()
-    assert self_loops == len(unique_cells)
+    assert self_loops == 5
 
 
-def test_caching_same_object():
+def test_builder_caching():
+    """Test builder caching of graphs and H3 indices."""
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
-    result1 = builder(lat_lons)
-    result2 = builder(lat_lons)
-    assert result1[0] is result2[0]
-    assert result1[1] is result2[1]
-    assert result1[2] is result2[2]
+    
+    res1 = builder(lat_lons)
+    res2 = builder(lat_lons)
+    
+    assert res1[0] is res2[0]
+    assert res1[1] is res2[1]
+    assert res1[2] is res2[2]
+    assert res1[3] is res2[3]
+    
+    different = [(0.0, 0.0), (1.0, 1.0)]
+    res3 = builder(different)
+    assert res1[0] is not res3[0]
 
 
-def test_caching_different_coords_rebuild():
+def test_validation_ranges():
+    """Test coordinate validation ranges."""
     builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    result1 = builder(lat_lons)
-    different = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]
-    result2 = builder(different)
-    assert result1[0] is not result2[0]
-
-
-def test_empty_list_raises():
-    builder = DynamicGraphBuilder(resolution=2)
+    
     with pytest.raises(ValueError, match="must not be empty"):
         builder([])
-
-
-def test_invalid_latitude_raises():
-    builder = DynamicGraphBuilder(resolution=2)
+        
     with pytest.raises(ValueError, match="latitude"):
         builder([(91.0, 0.0)])
-
-
-def test_negative_invalid_latitude_raises():
-    builder = DynamicGraphBuilder(resolution=2)
+        
     with pytest.raises(ValueError, match="latitude"):
         builder([(-91.0, 0.0)])
-
-
-def test_valid_boundary_latitudes():
-    builder = DynamicGraphBuilder(resolution=2)
-    result = builder([(-90.0, 0.0), (90.0, 180.0)])
-    assert result[0].edge_index.shape[1] == 2
-
-
-def test_edge_attr_matches_edge_count():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    enc, _ = builder.build_encoder_graph(lat_lons)
-    dec = builder.build_decoder_graph(lat_lons)
-    assert enc.edge_attr.shape[0] == enc.edge_index.shape[1]
-    assert dec.edge_attr.shape[0] == dec.edge_index.shape[1]
-
-
-def test_edge_attr_values_bounded():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    enc, _ = builder.build_encoder_graph(lat_lons)
-    assert enc.edge_attr.abs().max() <= 1.0
-
-
-def test_call_returns_four_items():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    result = builder(lat_lons)
-    assert len(result) == 4
-    enc_graph, dec_graph, lat_graph, h3_indices = result
-    assert isinstance(enc_graph, Data)
-    assert isinstance(dec_graph, Data)
-    assert isinstance(lat_graph, Data)
-    assert isinstance(h3_indices, list)
-
-
-def test_encoder_source_ordering():
-    builder = DynamicGraphBuilder(resolution=2)
-    lat_lons = _small_region()
-    enc_graph, _, _, _ = builder(lat_lons)
-    sources = enc_graph.edge_index[0].tolist()
-    assert sources == list(range(len(lat_lons)))
+        
+    res = builder([(-90.0, 0.0), (90.0, 180.0)])
+    assert res[0].edge_index.shape == (2, 2)
 
 
 def test_validate_lat_lons_standalone():
+    """Test standalone lat/lon validation function."""
     with pytest.raises(ValueError, match="must not be empty"):
         validate_lat_lons([])
     with pytest.raises(ValueError, match="latitude"):

--- a/tests/test_dynamic_graph_builder.py
+++ b/tests/test_dynamic_graph_builder.py
@@ -22,14 +22,14 @@ def test_encoder_graph():
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
     graph, h3_indices = builder.build_encoder_graph(lat_lons)
-    
+
     assert graph.edge_index.shape == (2, 25)
     assert graph.edge_index.dtype == torch.long
     assert graph.edge_index[0].tolist() == list(range(25))
     assert graph.edge_index[1].min().item() >= 25
     assert graph.edge_attr.shape == (25, 2)
     assert graph.edge_attr.abs().max() <= 1.0
-    
+
     total_h3 = h3.get_num_cells(2)
     assert all(0 <= idx < total_h3 for idx in h3_indices)
 
@@ -39,7 +39,7 @@ def test_decoder_graph():
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
     graph = builder.build_decoder_graph(lat_lons)
-    
+
     assert graph.edge_index.shape == (2, 175)
     assert graph.edge_index.dtype == torch.long
     assert graph.edge_attr.shape == (175, 2)
@@ -52,14 +52,14 @@ def test_latent_graph():
     lat_lons = _small_region()
     h3_cells = [h3.latlng_to_cell(lat, lon, 2) for lat, lon in lat_lons]
     unique_cells = sorted(set(h3_cells))
-    
+
     assert len(unique_cells) == 5
-    
+
     graph = builder.build_latent_graph(unique_cells)
-    
+
     assert graph.edge_index.shape == (2, 19)
     assert graph.edge_attr.shape == (19, 2)
-    
+
     src, dst = graph.edge_index[0], graph.edge_index[1]
     self_loops = (src == dst).sum().item()
     assert self_loops == 5
@@ -69,15 +69,15 @@ def test_builder_caching():
     """Test builder caching of graphs and H3 indices."""
     builder = DynamicGraphBuilder(resolution=2)
     lat_lons = _small_region()
-    
+
     res1 = builder(lat_lons)
     res2 = builder(lat_lons)
-    
+
     assert res1[0] is res2[0]
     assert res1[1] is res2[1]
     assert res1[2] is res2[2]
     assert res1[3] is res2[3]
-    
+
     different = [(0.0, 0.0), (1.0, 1.0)]
     res3 = builder(different)
     assert res1[0] is not res3[0]
@@ -86,16 +86,16 @@ def test_builder_caching():
 def test_validation_ranges():
     """Test coordinate validation ranges."""
     builder = DynamicGraphBuilder(resolution=2)
-    
+
     with pytest.raises(ValueError, match="must not be empty"):
         builder([])
-        
+
     with pytest.raises(ValueError, match="latitude"):
         builder([(91.0, 0.0)])
-        
+
     with pytest.raises(ValueError, match="latitude"):
         builder([(-91.0, 0.0)])
-        
+
     res = builder([(-90.0, 0.0), (90.0, 180.0)])
     assert res[0].edge_index.shape == (2, 2)
 

--- a/tests/test_dynamic_graph_builder.py
+++ b/tests/test_dynamic_graph_builder.py
@@ -1,0 +1,162 @@
+"""Tests for DynamicGraphBuilder.
+
+Covers graph construction, caching, validation, and the encoder/decoder
+topology asymmetry. Uses synthetic coordinates matching the patterns in
+tests/test_model.py.
+"""
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from graph_weather.models.layers.dynamic_graph_builder import DynamicGraphBuilder
+
+
+@pytest.fixture
+def builder():
+    return DynamicGraphBuilder(resolution=2)
+
+
+@pytest.fixture
+def small_region():
+    """A small 5x5 lat/lon patch centered on London."""
+    lat_lons = []
+    for lat in range(50, 55):
+        for lon in range(-2, 3):
+            lat_lons.append((float(lat), float(lon)))
+    return lat_lons
+
+
+class TestEncoderGraph:
+    def test_shape(self, builder, small_region):
+        graph, h3_indices = builder.build_encoder_graph(small_region)
+        assert graph.edge_index.shape[0] == 2
+        assert graph.edge_index.dtype == torch.long
+        assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
+        assert graph.edge_attr.shape[1] == 2
+
+    def test_one_edge_per_node(self, builder, small_region):
+        graph, _ = builder.build_encoder_graph(small_region)
+        assert graph.edge_index.shape[1] == len(small_region)
+
+    def test_h3_indices_returned(self, builder, small_region):
+        _, h3_indices = builder.build_encoder_graph(small_region)
+        assert len(h3_indices) > 0
+        assert all(isinstance(i, int) for i in h3_indices)
+        # Must be fewer unique H3 cells than coordinates
+        assert len(h3_indices) <= len(small_region)
+
+
+class TestDecoderGraph:
+    def test_more_edges_than_encoder(self, builder, small_region):
+        enc_graph, _ = builder.build_encoder_graph(small_region)
+        dec_graph = builder.build_decoder_graph(small_region)
+        # Decoder uses ring-1 neighborhood: ~7 edges per node vs 1
+        assert dec_graph.edge_index.shape[1] > enc_graph.edge_index.shape[1]
+
+    def test_shape(self, builder, small_region):
+        graph = builder.build_decoder_graph(small_region)
+        assert graph.edge_index.shape[0] == 2
+        assert graph.edge_index.dtype == torch.long
+        assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
+        assert graph.edge_attr.shape[1] == 2
+
+
+class TestLatentGraph:
+    def test_scoped_to_region(self, builder, small_region):
+        """Latent graph has far fewer nodes than the full global mesh."""
+        import h3 as h3_lib
+
+        h3_cells = [
+            h3_lib.latlng_to_cell(lat, lon, builder.resolution)
+            for lat, lon in small_region
+        ]
+        unique_cells = sorted(set(h3_cells))
+        graph = builder.build_latent_graph(unique_cells)
+
+        total_global = h3_lib.get_num_cells(builder.resolution)
+        # The latent graph node count (derived from unique_cells) is much
+        # smaller than the full global mesh
+        assert len(unique_cells) < total_global
+        assert graph.edge_index.shape[0] == 2
+        assert graph.edge_attr.shape[0] == graph.edge_index.shape[1]
+
+    def test_self_loops_present(self, builder, small_region):
+        """grid_disk(cell, 1) includes the cell itself, so self-loops exist."""
+        import h3 as h3_lib
+
+        h3_cells = [
+            h3_lib.latlng_to_cell(lat, lon, builder.resolution)
+            for lat, lon in small_region
+        ]
+        unique_cells = sorted(set(h3_cells))
+        graph = builder.build_latent_graph(unique_cells)
+
+        src, dst = graph.edge_index[0], graph.edge_index[1]
+        self_loops = (src == dst).sum().item()
+        assert self_loops == len(unique_cells)
+
+
+class TestCaching:
+    def test_same_object_returns_cached(self, builder, small_region):
+        result1 = builder(small_region)
+        result2 = builder(small_region)
+        # Same list object → same graph objects (identity check)
+        assert result1[0] is result2[0]
+        assert result1[1] is result2[1]
+        assert result1[2] is result2[2]
+
+    def test_different_coords_rebuild(self, builder, small_region):
+        result1 = builder(small_region)
+        different_region = [(0.0, 0.0), (1.0, 1.0), (2.0, 2.0)]
+        result2 = builder(different_region)
+        assert result1[0] is not result2[0]
+
+
+class TestValidation:
+    def test_empty_list_raises(self, builder):
+        with pytest.raises(ValueError, match="must not be empty"):
+            builder([])
+
+    def test_invalid_latitude_raises(self, builder):
+        with pytest.raises(ValueError, match="latitude"):
+            builder([(91.0, 0.0)])
+
+    def test_negative_invalid_latitude_raises(self, builder):
+        with pytest.raises(ValueError, match="latitude"):
+            builder([(-91.0, 0.0)])
+
+    def test_valid_boundary_latitudes(self, builder):
+        """Latitudes exactly at -90 and 90 should work."""
+        result = builder([(-90.0, 0.0), (90.0, 180.0)])
+        assert result[0].edge_index.shape[1] == 2
+
+
+class TestEdgeAttributes:
+    def test_edge_attr_matches_edge_count(self, builder, small_region):
+        enc, _ = builder.build_encoder_graph(small_region)
+        dec = builder.build_decoder_graph(small_region)
+        assert enc.edge_attr.shape[0] == enc.edge_index.shape[1]
+        assert dec.edge_attr.shape[0] == dec.edge_index.shape[1]
+
+    def test_edge_attr_values_bounded(self, builder, small_region):
+        """sin/cos values are always in [-1, 1]."""
+        enc, _ = builder.build_encoder_graph(small_region)
+        assert enc.edge_attr.abs().max() <= 1.0
+
+
+class TestCallInterface:
+    def test_returns_four_items(self, builder, small_region):
+        result = builder(small_region)
+        assert len(result) == 4
+        enc_graph, dec_graph, lat_graph, h3_indices = result
+        assert isinstance(enc_graph, Data)
+        assert isinstance(dec_graph, Data)
+        assert isinstance(lat_graph, Data)
+        assert isinstance(h3_indices, list)
+
+    def test_round_trip_ordering(self, builder, small_region):
+        """Encoder source nodes should be ordered 0..N-1 matching input."""
+        enc_graph, _, _, _ = builder(small_region)
+        sources = enc_graph.edge_index[0].tolist()
+        assert sources == list(range(len(small_region)))


### PR DESCRIPTION
# Pull Request

## Description

This PR adds `DynamicGraphBuilder`, which builds encoder, decoder, and latent H3 graphs from runtime lat/lon coordinates.

It supports movable regional graph construction for issue #3 without rebuilding the full model when coordinates change between batches.

The builder includes:

- encoder graph construction with one lat/lon to H3-cell edge per point
- decoder graph construction using each point's H3 cell and ring-1 neighbors
- latent graph construction scoped to the regional H3 cells
- cache reuse when the same coordinate object is passed repeatedly
- shared lat/lon validation in `graph_weather.utils`

Related to #3

## How Has This Been Tested?

The following tests were added and run using `pytest`:

- `tests/test_dynamic_graph_builder.py`
  - Encoder graph shape, dtype, and edge attributes
  - Decoder ring-1 connectivity
  - Regional latent graph construction
  - Cache reuse behavior
  - Empty and invalid latitude validation

Commands run:

- `.\.venv\Scripts\python.exe -m pytest tests/test_dynamic_graph_builder.py -q`
  - 18 passed, 1 warning

- `.\.venv\Scripts\python.exe -m pre_commit run --files graph_weather/models/layers/dynamic_graph_builder.py graph_weather/utils.py tests/test_dynamic_graph_builder.py`
  - Passed

I also ran `tests/test_model.py` with the new tests. That gave 37 passed and 2 local failures from existing `fengwu_ghr` tests because my local environment is missing `torch-cluster`.

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Not applicable - no data processing changes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings