### PR TITLE
feat: add RegionalForecaster for movable regional weather prediction

### DIFF
--- a/graph_weather/models/__init__.py
+++ b/graph_weather/models/__init__.py
@@ -14,3 +14,4 @@ from .layers.decoder import Decoder
 from .layers.encoder import Encoder
 from .layers.processor import Processor
 from .layers.stochastic_decomposition import StochasticDecompositionLayer
+from .regional_forecast import RegionalForecaster, RegionalForecasterConfig

--- a/graph_weather/models/regional_forecast.py
+++ b/graph_weather/models/regional_forecast.py
@@ -1,0 +1,193 @@
+"""Regional weather forecaster with movable high-res domain."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import h3
+import torch
+import torch.nn as nn
+
+from graph_weather.models.layers.dynamic_graph_builder import DynamicGraphBuilder
+from graph_weather.models.layers.graph_net_block import MLP, GraphProcessor
+from graph_weather.models.layers.processor import Processor
+
+
+@dataclass
+class RegionalForecasterConfig:
+    """Configuration for RegionalForecaster."""
+
+    resolution: int = 2
+    feature_dim: int = 78
+    aux_dim: int = 24
+    output_dim: Optional[int] = None
+    node_dim: int = 256
+    edge_dim: int = 256
+    num_blocks: int = 9
+    hidden_dim_processor_node: int = 256
+    hidden_dim_processor_edge: int = 256
+    hidden_layers_processor_node: int = 2
+    hidden_layers_processor_edge: int = 2
+    hidden_dim_decoder: int = 128
+    hidden_layers_decoder: int = 2
+    norm_type: str = "LayerNorm"
+    use_checkpointing: bool = False
+
+    def build(self) -> "RegionalForecaster":
+        """Build RegionalForecaster from this configuration."""
+        return RegionalForecaster(self)
+
+
+class RegionalForecaster(nn.Module):
+    """Regional weather forecaster with dynamic graph construction."""
+
+    def __init__(self, config: RegionalForecasterConfig):
+        """Initialize RegionalForecaster from config."""
+        super().__init__()
+        self.config = config
+        input_dim = config.feature_dim + config.aux_dim
+        output_dim = config.output_dim if config.output_dim is not None else config.feature_dim
+        self.output_dim = output_dim
+
+        self.graph_builder = DynamicGraphBuilder(resolution=config.resolution)
+
+        # Learnable embedding per H3 cell; forward() indexes the regional subset
+        self.h3_embeddings = nn.Parameter(
+            torch.zeros(h3.get_num_cells(config.resolution), input_dim)
+        )
+
+        # Encoder
+        self.node_encoder = MLP(
+            input_dim,
+            config.node_dim,
+            config.hidden_dim_processor_node,
+            config.hidden_layers_processor_node,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.edge_encoder = MLP(
+            2,
+            config.edge_dim,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.encoder_gnn = GraphProcessor(
+            1,
+            config.node_dim,
+            config.edge_dim,
+            config.hidden_dim_processor_node,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_node,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            use_checkpointing=config.use_checkpointing,
+        )
+
+        # Processor
+        self.latent_edge_encoder = MLP(
+            2,
+            config.edge_dim,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.processor = Processor(
+            input_dim=config.node_dim,
+            edge_dim=config.edge_dim,
+            num_blocks=config.num_blocks,
+            hidden_dim_processor_edge=config.hidden_dim_processor_edge,
+            hidden_layers_processor_node=config.hidden_layers_processor_node,
+            hidden_dim_processor_node=config.hidden_dim_processor_node,
+            hidden_layers_processor_edge=config.hidden_layers_processor_edge,
+            mlp_norm_type=config.norm_type,
+        )
+
+        # Decoder
+        self.decoder_edge_encoder = MLP(
+            2,
+            config.edge_dim,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.decoder_gnn = GraphProcessor(
+            1,
+            config.node_dim,
+            config.edge_dim,
+            config.hidden_dim_processor_node,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_node,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            use_checkpointing=config.use_checkpointing,
+        )
+        self.node_decoder = MLP(
+            config.node_dim,
+            output_dim,
+            config.hidden_dim_decoder,
+            config.hidden_layers_decoder,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        lat_lons: list,
+    ) -> torch.Tensor:
+        """
+        Regional weather forecast for a given set of coordinates.
+
+        Args:
+            features: Input features [B, N_obs, feature_dim + aux_dim]
+            lat_lons: List of (lat, lon) for this region
+
+        Returns:
+            Predicted next state [B, N_obs, output_dim]
+        """
+        batch_size = features.shape[0]
+        num_obs = features.shape[1]
+
+        # Build dynamic graphs from coordinates
+        enc_graph, _, lat_graph, h3_indices = self.graph_builder(lat_lons)
+        enc_graph = enc_graph.to(features.device)
+        lat_graph = lat_graph.to(features.device)
+
+        # Get regional H3 embeddings from global table
+        regional_h3 = self.h3_embeddings[h3_indices]
+
+        # Encode edges (shared across batch)
+        enc_edge_attr = self.edge_encoder(enc_graph.edge_attr)
+        latent_edge_attr = self.latent_edge_encoder(lat_graph.edge_attr)
+
+        # Decoder uses reversed encoder edges: same nodes, opposite direction
+        dec_edge_index = enc_graph.edge_index.flip(0)
+        dec_edge_attr = self.decoder_edge_encoder(enc_graph.edge_attr)
+
+        batch_outputs = []
+        for i in range(batch_size):
+            # Encode: obs + H3 nodes through bipartite GNN
+            nodes = torch.cat([features[i], regional_h3], dim=0)
+            nodes = self.node_encoder(nodes)
+            nodes, _ = self.encoder_gnn(nodes, enc_graph.edge_index, enc_edge_attr)
+            h3_features = nodes[num_obs:]
+
+            # Process: N rounds of H3 message passing
+            h3_features = self.processor(h3_features, lat_graph.edge_index, latent_edge_attr)
+
+            # Decode: H3 -> obs through reversed bipartite GNN
+            obs_placeholders = torch.zeros(num_obs, self.config.node_dim, device=features.device)
+            dec_nodes = torch.cat([obs_placeholders, h3_features], dim=0)
+            dec_nodes, _ = self.decoder_gnn(dec_nodes, dec_edge_index, dec_edge_attr)
+            obs_out = self.node_decoder(dec_nodes[:num_obs])
+            batch_outputs.append(obs_out)
+
+        out = torch.stack(batch_outputs, dim=0)
+
+        # Residual: predict delta, add to input
+        out = out + features[..., : self.output_dim]
+
+        return out

--- a/tests/test_regional_forecast.py
+++ b/tests/test_regional_forecast.py
@@ -1,0 +1,122 @@
+"""Tests for RegionalForecaster model."""
+
+import torch
+
+from graph_weather.models.regional_forecast import RegionalForecasterConfig
+
+
+def _small_config():
+    """Create a small config for fast testing."""
+    return RegionalForecasterConfig(
+        feature_dim=12,
+        aux_dim=4,
+        node_dim=32,
+        edge_dim=32,
+        num_blocks=2,
+        hidden_dim_processor_node=32,
+        hidden_dim_processor_edge=32,
+        hidden_dim_decoder=32,
+    )
+
+
+def _uk_latlons():
+    """Five UK coordinates."""
+    return [(51.5, -0.1), (52.0, 0.5), (53.0, -1.0), (54.0, -2.0), (50.0, -3.0)]
+
+
+def _germany_latlons():
+    """Three Germany coordinates."""
+    return [(52.5, 13.4), (48.1, 11.6), (50.9, 6.9)]
+
+
+def test_config_build():
+    """Config.build() returns a working model."""
+    config = _small_config()
+    model = config.build()
+    assert hasattr(model, "forward")
+    assert hasattr(model, "graph_builder")
+    assert hasattr(model, "h3_embeddings")
+
+
+def test_forward_shape():
+    """Output shape matches [B, N_obs, output_dim]."""
+    model = _small_config().build()
+    lat_lons = _uk_latlons()
+    features = torch.randn(2, 5, 16)  # 12 + 4 = 16
+
+    out = model(features, lat_lons)
+    assert out.shape == (2, 5, 12)
+
+
+def test_no_nan_output():
+    """Forward pass produces no NaN values."""
+    model = _small_config().build()
+    features = torch.randn(2, 5, 16)
+
+    out = model(features, _uk_latlons())
+    assert not torch.isnan(out).any()
+
+
+def test_different_coords_per_forward():
+    """Same model handles different regions in successive forward passes."""
+    model = _small_config().build()
+
+    out_uk = model(torch.randn(1, 5, 16), _uk_latlons())
+    assert out_uk.shape == (1, 5, 12)
+
+    out_de = model(torch.randn(1, 3, 16), _germany_latlons())
+    assert out_de.shape == (1, 3, 12)
+
+
+def test_variable_length_coords():
+    """Model works with different observation counts."""
+    model = _small_config().build()
+
+    # 5 observations
+    out5 = model(torch.randn(1, 5, 16), _uk_latlons())
+    assert out5.shape == (1, 5, 12)
+
+    # 3 observations
+    out3 = model(torch.randn(1, 3, 16), _germany_latlons())
+    assert out3.shape == (1, 3, 12)
+
+
+def test_backward_pass():
+    """Gradients flow through the full pipeline."""
+    model = _small_config().build()
+    features = torch.randn(1, 5, 16)
+
+    out = model(features, _uk_latlons())
+    loss = out.sum()
+    loss.backward()
+
+    # Check gradients exist on key parameters
+    assert model.h3_embeddings.grad is not None
+    has_grad = any(p.grad is not None for p in model.node_encoder.parameters())
+    assert has_grad
+
+
+def test_output_dim_override():
+    """Custom output_dim produces the right shape."""
+    config = _small_config()
+    config.output_dim = 6
+    model = config.build()
+    features = torch.randn(1, 5, 16)
+
+    out = model(features, _uk_latlons())
+    assert out.shape == (1, 5, 6)
+
+
+def test_residual_connection():
+    """Output includes a residual from the input features."""
+    model = _small_config().build()
+    features = torch.randn(1, 5, 16)
+
+    # With zero weights, output should be close to the input residual
+    with torch.no_grad():
+        for p in model.parameters():
+            p.zero_()
+
+    out = model(features, _uk_latlons())
+    expected_residual = features[..., :12]
+    assert torch.allclose(out, expected_residual, atol=1e-5)


### PR DESCRIPTION
# Pull Request

## Description

This PR adds `RegionalForecaster`, which performs encode-process-decode on runtime-generated H3 meshes for regional weather prediction.

It builds on the `DynamicGraphBuilder` from #219 to support movable high-res regions for issue #3. The region can change between forward passes without rebuilding the model.

The model includes:

- `RegionalForecasterConfig` dataclass with `build()` method
- Encoder, Processor, Decoder composed from existing `MLP`, `GraphProcessor`, `Processor` blocks
- Global H3 embedding table indexed per-batch for the regional subset
- Decoder using reversed encoder edges
- Residual connection on the output
- Export in `graph_weather.models.__init__`

Related to #3

## How Has This Been Tested?

The following tests were added and run using `pytest`:

- `tests/test_regional_forecast.py`
  - Config build
  - Forward output shape
  - No NaN output
  - Different coordinates per forward (UK then Germany)
  - Variable observation counts
  - Backward pass and gradient flow
  - Custom output_dim override
  - Residual connection correctness

Commands run:

- `.\.venv\Scripts\python.exe -m pytest tests/test_regional_forecast.py -q`
  - 8 passed, 1 warning

- `.\.venv\Scripts\python.exe -m pre_commit run --files graph_weather/models/regional_forecast.py tests/test_regional_forecast.py graph_weather/models/__init__.py`
  - Passed

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Not applicable - no data processing changes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
