### PR TITLE
feat: add BoundaryNudgingLayer for regional-global blending

### DIFF
--- a/graph_weather/models/regional_forecast.py
+++ b/graph_weather/models/regional_forecast.py
@@ -1,5 +1,6 @@
 """Regional weather forecaster with movable high-res domain."""
 
+import math
 from dataclasses import dataclass
 from typing import Optional
 
@@ -31,10 +32,102 @@ class RegionalForecasterConfig:
     hidden_layers_decoder: int = 2
     norm_type: str = "LayerNorm"
     use_checkpointing: bool = False
+    enable_nudging: bool = False
+    nudging_hidden_dim: int = 64
 
     def build(self) -> "RegionalForecaster":
         """Build RegionalForecaster from this configuration."""
         return RegionalForecaster(self)
+
+
+class BoundaryNudgingLayer(nn.Module):
+    """Blends regional predictions with global context at domain boundaries.
+
+    Uses a hybrid approach: distance-based relaxation prior
+    plus a learned MLP correction. Alpha=0 at the region center
+    (trust regional), alpha=1 at edges (trust global).
+    """
+
+    def __init__(self, feature_dim: int, hidden_dim: int = 64):
+        """Initialize BoundaryNudgingLayer.
+
+        Args:
+            feature_dim: Dimension of regional/global predictions.
+            hidden_dim: Hidden dimension for the blending MLP.
+        """
+        super().__init__()
+        self.blend_mlp = MLP(
+            feature_dim * 2 + 1,
+            1,
+            hidden_dim,
+            1,
+            None,
+        )
+
+    def forward(
+        self,
+        regional: torch.Tensor,
+        global_context: torch.Tensor,
+        lat_lons: list,
+    ) -> torch.Tensor:
+        """Blend regional predictions with global context.
+
+        Args:
+            regional: Regional prediction [B, N_obs, feature_dim]
+            global_context: Global prediction [B, N_obs, feature_dim]
+            lat_lons: List of (lat, lon) for observations
+
+        Returns:
+            Blended output [B, N_obs, feature_dim]
+        """
+        alpha_prior = self._compute_relaxation_weights(lat_lons, regional.device)
+        alpha_prior = alpha_prior.unsqueeze(0).expand(regional.shape[0], -1, -1)
+
+        mlp_input = torch.cat([regional, global_context, alpha_prior], dim=-1)
+        alpha_correction = self.blend_mlp(mlp_input)
+        alpha = torch.clamp(alpha_prior + alpha_correction, 0.0, 1.0)
+
+        return (1 - alpha) * regional + alpha * global_context
+
+    @staticmethod
+    def _compute_relaxation_weights(
+        lat_lons: list,
+        device: torch.device,
+    ) -> torch.Tensor:
+        """Compute distance-based relaxation weights from region centroid.
+
+        Args:
+            lat_lons: List of (lat, lon) tuples.
+            device: Target device for the output tensor.
+
+        Returns:
+            Weights tensor [N_obs, 1] with 0 at center, 1 at edges.
+        """
+        lats = torch.tensor([ll[0] for ll in lat_lons], dtype=torch.float32)
+        lons = torch.tensor([ll[1] for ll in lat_lons], dtype=torch.float32)
+
+        # Convert to radians for haversine
+        lats_rad = lats * (math.pi / 180.0)
+        lons_rad = lons * (math.pi / 180.0)
+        center_lat = lats_rad.mean()
+        center_lon = lons_rad.mean()
+
+        # Haversine distance from centroid
+        dlat = lats_rad - center_lat
+        dlon = lons_rad - center_lon
+        a = torch.sin(dlat / 2) ** 2 + (
+            torch.cos(lats_rad) * torch.cos(center_lat) * torch.sin(dlon / 2) ** 2
+        )
+        dist = 2 * torch.asin(torch.sqrt(torch.clamp(a, 0.0, 1.0)))
+
+        # Normalize to [0, 1]
+        max_dist = dist.max()
+        if max_dist > 0:
+            weights = dist / max_dist
+        else:
+            weights = torch.zeros_like(dist)
+
+        return weights.unsqueeze(-1).to(device)
 
 
 class RegionalForecaster(nn.Module):
@@ -47,6 +140,11 @@ class RegionalForecaster(nn.Module):
         input_dim = config.feature_dim + config.aux_dim
         output_dim = config.output_dim if config.output_dim is not None else config.feature_dim
         self.output_dim = output_dim
+
+        if config.enable_nudging:
+            self.nudging = BoundaryNudgingLayer(output_dim, config.nudging_hidden_dim)
+        else:
+            self.nudging = None
 
         self.graph_builder = DynamicGraphBuilder(resolution=config.resolution)
 
@@ -137,6 +235,7 @@ class RegionalForecaster(nn.Module):
         self,
         features: torch.Tensor,
         lat_lons: list,
+        global_context: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """
         Regional weather forecast for a given set of coordinates.
@@ -144,6 +243,8 @@ class RegionalForecaster(nn.Module):
         Args:
             features: Input features [B, N_obs, feature_dim + aux_dim]
             lat_lons: List of (lat, lon) for this region
+            global_context: Global prediction [B, N_obs, output_dim] for
+                boundary nudging. Ignored when nudging is disabled.
 
         Returns:
             Predicted next state [B, N_obs, output_dim]
@@ -189,5 +290,9 @@ class RegionalForecaster(nn.Module):
 
         # Residual: predict delta, add to input
         out = out + features[..., : self.output_dim]
+
+        # Boundary nudging: blend with global context at domain edges
+        if self.nudging is not None and global_context is not None:
+            out = self.nudging(out, global_context, lat_lons)
 
         return out

--- a/tests/test_regional_forecast.py
+++ b/tests/test_regional_forecast.py
@@ -2,7 +2,10 @@
 
 import torch
 
-from graph_weather.models.regional_forecast import RegionalForecasterConfig
+from graph_weather.models.regional_forecast import (
+    BoundaryNudgingLayer,
+    RegionalForecasterConfig,
+)
 
 
 def _small_config():
@@ -120,3 +123,78 @@ def test_residual_connection():
     out = model(features, _uk_latlons())
     expected_residual = features[..., :12]
     assert torch.allclose(out, expected_residual, atol=1e-5)
+
+
+def _nudging_config():
+    """Config with nudging enabled."""
+    return RegionalForecasterConfig(
+        feature_dim=12,
+        aux_dim=4,
+        node_dim=32,
+        edge_dim=32,
+        num_blocks=2,
+        hidden_dim_processor_node=32,
+        hidden_dim_processor_edge=32,
+        hidden_dim_decoder=32,
+        enable_nudging=True,
+        nudging_hidden_dim=16,
+    )
+
+
+def test_nudging_disabled_unchanged():
+    """Output is identical with enable_nudging=False (backward compat)."""
+    config_off = _small_config()
+    model = config_off.build()
+    assert model.nudging is None
+
+    features = torch.randn(1, 5, 16)
+    global_ctx = torch.randn(1, 5, 12)
+    out = model(features, _uk_latlons(), global_context=global_ctx)
+    out_no_ctx = model(features, _uk_latlons())
+    assert torch.allclose(out, out_no_ctx)
+
+
+def test_nudging_no_context_unchanged():
+    """Nudging enabled but global_context=None produces same output."""
+    model = _nudging_config().build()
+    features = torch.randn(1, 5, 16)
+
+    out = model(features, _uk_latlons(), global_context=None)
+    assert out.shape == (1, 5, 12)
+    assert not torch.isnan(out).any()
+
+
+def test_nudging_changes_output():
+    """Global context causes output to differ from no-context case."""
+    model = _nudging_config().build()
+    features = torch.randn(1, 5, 16)
+    global_ctx = torch.randn(1, 5, 12) * 10.0
+
+    out_no_ctx = model(features, _uk_latlons(), global_context=None)
+    out_with_ctx = model(features, _uk_latlons(), global_context=global_ctx)
+    assert not torch.allclose(out_no_ctx, out_with_ctx)
+
+
+def test_relaxation_weights_range():
+    """Alpha prior is in [0, 1] with max at the farthest point."""
+    weights = BoundaryNudgingLayer._compute_relaxation_weights(
+        _uk_latlons(), torch.device("cpu")
+    )
+    assert weights.shape == (5, 1)
+    assert weights.min() >= 0.0
+    assert weights.max() <= 1.0
+    assert torch.isclose(weights.max(), torch.tensor(1.0))
+
+
+def test_nudging_backward_pass():
+    """Gradients flow through the nudging layer."""
+    model = _nudging_config().build()
+    features = torch.randn(1, 5, 16)
+    global_ctx = torch.randn(1, 5, 12)
+
+    out = model(features, _uk_latlons(), global_context=global_ctx)
+    loss = out.sum()
+    loss.backward()
+
+    has_grad = any(p.grad is not None for p in model.nudging.parameters())
+    assert has_grad

--- a/tests/test_regional_forecast.py
+++ b/tests/test_regional_forecast.py
@@ -177,9 +177,7 @@ def test_nudging_changes_output():
 
 def test_relaxation_weights_range():
     """Alpha prior is in [0, 1] with max at the farthest point."""
-    weights = BoundaryNudgingLayer._compute_relaxation_weights(
-        _uk_latlons(), torch.device("cpu")
-    )
+    weights = BoundaryNudgingLayer._compute_relaxation_weights(_uk_latlons(), torch.device("cpu"))
     assert weights.shape == (5, 1)
     assert weights.min() >= 0.0
     assert weights.max() <= 1.0


### PR DESCRIPTION
# Pull Request

## Description

This PR adds `BoundaryNudgingLayer`, which blends regional predictions with global context at domain boundaries using a relaxation zone.

It builds on `RegionalForecaster` from #221 to support boundary conditioning for issue #3. The layer is opt-in and does not change behavior when disabled.

The layer includes:

- Distance-based relaxation prior using haversine distance from region centroid
- Learned MLP correction on top of the geometric prior
- Smooth blending: alpha=0 at center (trust regional), alpha=1 at edges (trust global)
- Integration into `RegionalForecaster.forward()` after the residual connection
- Two new config fields: `enable_nudging` (default False), `nudging_hidden_dim`

Related to #3

## How Has This Been Tested?

The following tests were added and run using `pytest`:

- `tests/test_regional_forecast.py`
  - Nudging disabled does not change output (backward compat)
  - Nudging enabled with no global context produces valid output
  - Global context changes output when nudging is enabled
  - Relaxation weights are in [0, 1] with max at farthest point
  - Gradients flow through the nudging layer

Commands run:

- `.\.venv\Scripts\python.exe -m pytest tests/test_regional_forecast.py -v`
  - 13 passed, 1 warning

- `.\.venv\Scripts\python.exe -m ruff check graph_weather/models/regional_forecast.py tests/test_regional_forecast.py`
  - Passed

_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [x] Not applicable - no data processing changes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
