### PR TITLE
feat: add RegionalDataset for movable IFS sub-grid sampling

### DIFF
--- a/graph_weather/data/regional_dataset.py
+++ b/graph_weather/data/regional_dataset.py
@@ -1,0 +1,164 @@
+"""Dataset that samples movable high-resolution sub-grids from IFS analysis.
+
+Each sample is a bounding box at a random location and timestep, drawn from the
+regular lat/lon IFS ``hres_analysis`` grid. It yields a ``(features, lat_lons,
+target)`` tuple shaped for ``RegionalForecaster.forward``: a region that can move
+anywhere on the globe per sample (Issue #3).
+"""
+
+import numpy as np
+import torch
+import xarray as xr
+from torch.utils.data import Dataset
+
+CORE_SURFACE = [
+    "2_metre_temperature",
+    "2_metre_dewpoint_temperature",
+    "10_metre_u_wind_component",
+    "10_metre_v_wind_component",
+    "mean_sea_level_pressure",
+    "surface_pressure",
+    "total_cloud_cover",
+    "total_column_water_vapour",
+    "skin_temperature",
+]
+
+# Per-variable mean/std measured from 40 random IFS timesteps (stride-20 global
+# subsample); see scripts/exploration/compute_ifs_stats.py. Override via mean/std args.
+CORE_SURFACE_MEAN = {
+    "2_metre_temperature": 278.9795,
+    "2_metre_dewpoint_temperature": 274.3301,
+    "10_metre_u_wind_component": -0.0102,
+    "10_metre_v_wind_component": 0.1637,
+    "mean_sea_level_pressure": 100925.1357,
+    "surface_pressure": 96529.5451,
+    "total_cloud_cover": 0.6729,
+    "total_column_water_vapour": 19.0496,
+    "skin_temperature": 279.3837,
+}
+CORE_SURFACE_STD = {
+    "2_metre_temperature": 21.3684,
+    "2_metre_dewpoint_temperature": 20.7277,
+    "10_metre_u_wind_component": 5.647,
+    "10_metre_v_wind_component": 4.8797,
+    "mean_sea_level_pressure": 1351.9402,
+    "surface_pressure": 9757.2853,
+    "total_cloud_cover": 0.3823,
+    "total_column_water_vapour": 16.9003,
+    "skin_temperature": 22.4583,
+}
+
+DEFAULT_STORE = "bkr/ifs/hres_analysis.icechunk"
+
+
+def open_ifs_store(store_url: str) -> xr.Dataset:
+    """Open an IFS Icechunk store on Source Cooperative for anonymous reading."""
+    import os
+
+    os.environ.setdefault("AWS_EC2_METADATA_DISABLED", "true")
+    import icechunk
+
+    bucket, prefix = store_url.split("/", 1)
+    storage = icechunk.s3_storage(
+        bucket=bucket,
+        prefix=prefix,
+        endpoint_url="https://data.source.coop",
+        region="us-east-1",
+        anonymous=True,
+        force_path_style=True,
+    )
+    repo = icechunk.Repository.open(storage)
+    session = repo.readonly_session("main")
+    return xr.open_zarr(session.store, consolidated=False, zarr_format=3)
+
+
+class RegionalDataset(Dataset):
+    """Movable sub-grid samples from a regular lat/lon IFS analysis grid.
+
+    Args:
+        dataset: An open ``xarray.Dataset`` to sample from. When ``None``, the
+            store at ``store_url`` is opened.
+        store_url: Source Cooperative ``<bucket>/<prefix>`` of the IFS store.
+        variables: Surface variable names to stack into the feature dimension.
+        extent_deg: Side length of the square bounding box, in degrees.
+        max_points: Cap on observation points per sample (subsampled if exceeded).
+        seed: Base seed; sample ``idx`` uses ``seed + idx`` so boxes move per idx.
+        mean: Per-variable means for standardisation.
+        std: Per-variable standard deviations for standardisation.
+    """
+
+    def __init__(
+        self,
+        dataset: xr.Dataset = None,
+        store_url: str = DEFAULT_STORE,
+        variables: list = None,
+        extent_deg: float = 20.0,
+        max_points: int = 2000,
+        seed: int = 0,
+        mean: dict = None,
+        std: dict = None,
+    ):
+        """Open the source grid and record sampling configuration."""
+        super().__init__()
+        self.data = dataset if dataset is not None else open_ifs_store(store_url)
+        self.variables = variables if variables is not None else CORE_SURFACE
+        self.extent_deg = extent_deg
+        self.max_points = max_points
+        self.seed = seed
+        self.mean = mean if mean is not None else CORE_SURFACE_MEAN
+        self.std = std if std is not None else CORE_SURFACE_STD
+        self.lat = self.data["latitude"].values
+        self.lon = self.data["longitude"].values
+
+    def __len__(self) -> int:
+        """Number of t -> t+1 sample pairs."""
+        return int(self.data.sizes["time"]) - 1
+
+    def _sample_box(self, rng):
+        """Pick a movable bbox center and return point grid indices and coords."""
+        half = self.extent_deg / 2.0
+        lat_c = rng.uniform(self.lat.min() + half, self.lat.max() - half)
+        lon_c = rng.uniform(self.lon.min() + half, self.lon.max() - half)
+
+        lat_idx = np.flatnonzero(np.abs(self.lat - lat_c) <= half)
+        lon_idx = np.flatnonzero(np.abs(self.lon - lon_c) <= half)
+
+        glat, glon = np.meshgrid(self.lat[lat_idx], self.lon[lon_idx], indexing="ij")
+        giy, gix = np.meshgrid(
+            np.arange(len(lat_idx)), np.arange(len(lon_idx)), indexing="ij"
+        )
+        flat_lat, flat_lon = glat.ravel(), glon.ravel()
+        flat_iy, flat_ix = giy.ravel(), gix.ravel()
+
+        n = min(self.max_points, flat_lat.size)
+        pick = rng.choice(flat_lat.size, size=n, replace=False)
+        return (
+            lat_idx,
+            lon_idx,
+            flat_iy[pick],
+            flat_ix[pick],
+            flat_lat[pick],
+            flat_lon[pick],
+        )
+
+    def _extract(self, t, lat_idx, lon_idx, iy, ix):
+        """Stack standardised variables at the sampled points for timestep t."""
+        cols = []
+        for v in self.variables:
+            arr = self.data[v].isel(
+                time=t, latitude=lat_idx, longitude=lon_idx
+            ).values
+            col = (arr[iy, ix] - self.mean[v]) / self.std[v]
+            cols.append(col)
+        feat = np.stack(cols, axis=-1).astype(np.float32)
+        return np.nan_to_num(feat, nan=0.0)
+
+    def __getitem__(self, idx):
+        """Return (features [N, F], lat_lons list, target [N, F]) for one box."""
+        rng = np.random.default_rng(self.seed + idx)
+        lat_idx, lon_idx, iy, ix, plat, plon = self._sample_box(rng)
+
+        features = torch.from_numpy(self._extract(idx, lat_idx, lon_idx, iy, ix))
+        target = torch.from_numpy(self._extract(idx + 1, lat_idx, lon_idx, iy, ix))
+        lat_lons = [(float(a), float(b)) for a, b in zip(plat, plon)]
+        return features, lat_lons, target

--- a/graph_weather/data/regional_dataset.py
+++ b/graph_weather/data/regional_dataset.py
@@ -124,9 +124,7 @@ class RegionalDataset(Dataset):
         lon_idx = np.flatnonzero(np.abs(self.lon - lon_c) <= half)
 
         glat, glon = np.meshgrid(self.lat[lat_idx], self.lon[lon_idx], indexing="ij")
-        giy, gix = np.meshgrid(
-            np.arange(len(lat_idx)), np.arange(len(lon_idx)), indexing="ij"
-        )
+        giy, gix = np.meshgrid(np.arange(len(lat_idx)), np.arange(len(lon_idx)), indexing="ij")
         flat_lat, flat_lon = glat.ravel(), glon.ravel()
         flat_iy, flat_ix = giy.ravel(), gix.ravel()
 
@@ -145,9 +143,7 @@ class RegionalDataset(Dataset):
         """Stack standardised variables at the sampled points for timestep t."""
         cols = []
         for v in self.variables:
-            arr = self.data[v].isel(
-                time=t, latitude=lat_idx, longitude=lon_idx
-            ).values
+            arr = self.data[v].isel(time=t, latitude=lat_idx, longitude=lon_idx).values
             col = (arr[iy, ix] - self.mean[v]) / self.std[v]
             cols.append(col)
         feat = np.stack(cols, axis=-1).astype(np.float32)

--- a/tests/test_regional_dataset.py
+++ b/tests/test_regional_dataset.py
@@ -1,0 +1,90 @@
+"""Tests for RegionalDataset using a synthetic in-memory grid (no cloud)."""
+
+import numpy as np
+import torch
+import xarray as xr
+
+from graph_weather.data.regional_dataset import CORE_SURFACE, RegionalDataset
+from graph_weather.models.regional_forecast import RegionalForecasterConfig
+
+
+def _synthetic_ds(n_time=4, n_lat=40, n_lon=80):
+    """Build a regular lat/lon dataset with the CORE_SURFACE variables."""
+    lat = np.linspace(-80.0, 80.0, n_lat)
+    lon = np.linspace(-180.0, 179.0, n_lon)
+    rng = np.random.default_rng(0)
+    data = {
+        v: (("time", "latitude", "longitude"), rng.standard_normal((n_time, n_lat, n_lon)))
+        for v in CORE_SURFACE
+    }
+    return xr.Dataset(data, coords={"latitude": lat, "longitude": lon, "time": np.arange(n_time)})
+
+
+def _dataset(**kwargs):
+    """RegionalDataset over the synthetic grid with test-friendly defaults."""
+    return RegionalDataset(dataset=_synthetic_ds(), extent_deg=40.0, max_points=100, **kwargs)
+
+
+def test_sample_shapes():
+    """Features and target are [N, F]; lat_lons has N entries; F == len(CORE)."""
+    features, lat_lons, target = _dataset()[0]
+    n = features.shape[0]
+    assert features.shape == (n, len(CORE_SURFACE))
+    assert target.shape == (n, len(CORE_SURFACE))
+    assert len(lat_lons) == n
+
+
+def test_len_is_time_minus_one():
+    """One sample per t -> t+1 pair."""
+    assert len(_dataset()) == 3
+
+
+def test_lat_lons_is_list_of_tuples():
+    """lat_lons must be a plain Python list of (lat, lon) for the graph builder."""
+    _, lat_lons, _ = _dataset()[0]
+    assert isinstance(lat_lons, list)
+    assert isinstance(lat_lons[0], tuple) and len(lat_lons[0]) == 2
+
+
+def test_feeds_regional_forecaster():
+    """Loader output drives RegionalForecaster with aux_dim=0 and no shape error."""
+    features, lat_lons, _ = _dataset()[0]
+    model = RegionalForecasterConfig(
+        feature_dim=len(CORE_SURFACE), aux_dim=0, node_dim=32, edge_dim=32, num_blocks=2
+    ).build()
+    out = model(features.unsqueeze(0), lat_lons)
+    assert out.shape == (1, features.shape[0], len(CORE_SURFACE))
+
+
+def test_movable_centers():
+    """Different idx samples a different bounding box location."""
+    ds = _dataset()
+    _, ll0, _ = ds[0]
+    _, ll1, _ = ds[1]
+    assert ll0 != ll1
+
+
+def test_points_in_domain():
+    """Sampled coordinates stay within the grid extent for every sample."""
+    ds = _dataset()
+    for i in range(len(ds)):
+        _, lat_lons, _ = ds[i]
+        lats = [a for a, _ in lat_lons]
+        lons = [b for _, b in lat_lons]
+        assert min(lats) >= -80.0 and max(lats) <= 80.0
+        assert min(lons) >= -180.0 and max(lons) <= 179.0
+
+
+def test_max_points_cap():
+    """Number of points never exceeds max_points."""
+    features, _, _ = RegionalDataset(dataset=_synthetic_ds(), extent_deg=60.0, max_points=20)[0]
+    assert features.shape[0] <= 20
+
+
+def test_nan_filled():
+    """A fully-NaN variable produces no NaN in the output (fill after normalize)."""
+    ds_syn = _synthetic_ds()
+    ds_syn["total_cloud_cover"][:] = np.nan
+    features, _, target = RegionalDataset(dataset=ds_syn, extent_deg=40.0, max_points=100)[0]
+    assert not torch.isnan(features).any()
+    assert not torch.isnan(target).any()


### PR DESCRIPTION
# Pull Request

## Description

Adds `RegionalDataset`, which feeds `RegionalForecaster` with real data for the first time (until now everything ran on `torch.randn`).

Each sample is a movable sub-grid drawn from the IFS `hres_analysis` store: pick a random bounding box and timestep, slice that high-res crop off the regular lat/lon grid, and return `(features, lat_lons, target)` where target is the same points one timestep ahead. The region moves per sample, which is the point of #3  one model that has to work anywhere, not a fixed domain.

Starting from a single global source (IFS) on purpose: the variables stay consistent and the box can sit anywhere on the globe. Approach confirmed with @jacobbieker on #3. Real regional NWP (MetOffice UK 2km, ICON-D2) would come later as a second source.

Details:
- 9 core surface variables (temperature, dewpoint, 10m winds, pressures, cloud cover, column water vapour, skin temp); surface-type-agnostic so they're valid in any box.
- Per-variable mean/std measured from 40 IFS timesteps; standardize then fill missing values with 0 (so a missing cell reads as the variable's mean, not a physical zero).
- Bounding-box center is clamped inward so the box stays in-domain; never crosses the antimeridian (loses a thin strip near ±180, fine for now).
- `lat_lons` returned as a plain Python list of (lat, lon) tuples to match `RegionalForecaster.forward`.

global_context / boundary nudging and solar/static aux features are deferred to keep this to one concern.

Related to #3

## How Has This Been Tested?

Added `tests/test_regional_dataset.py` - plain pytest, synthetic in-memory `xr.Dataset` so CI never touches S3:
- output shapes (features `[N, F]`, lat_lons length N, target `[N, F]`)
- output feeds `RegionalForecaster(feature_dim=F, aux_dim=0)` without shape error
- different sample index → different bounding box (movable)
- sampled coordinates stay within the grid extent
- max_points cap honored
- a fully-missing variable produces no NaN in the output

Commands:
- `pytest tests/test_regional_dataset.py -v` → 8 passed
- `pytest tests/test_regional_dataset.py tests/test_regional_forecast.py -q` → 21 passed
- `ruff check graph_weather/data/regional_dataset.py tests/test_regional_dataset.py` → clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
