### PR TITLE
feat: add coarse global_context to RegionalDataset for boundary nudging

### DIFF
--- a/graph_weather/data/regional_dataset.py
+++ b/graph_weather/data/regional_dataset.py
@@ -190,8 +190,6 @@ class RegionalDataset(Dataset):
 
         features = torch.from_numpy(self._extract(idx, lat_idx, lon_idx, iy, ix))
         target = torch.from_numpy(self._extract(idx + 1, lat_idx, lon_idx, iy, ix))
-        global_context = torch.from_numpy(
-            self._extract(idx, lat_idx, lon_idx, iy, ix, coarse=True)
-        )
+        global_context = torch.from_numpy(self._extract(idx, lat_idx, lon_idx, iy, ix, coarse=True))
         lat_lons = [(float(a), float(b)) for a, b in zip(plat, plon)]
         return features, lat_lons, target, global_context

--- a/graph_weather/data/regional_dataset.py
+++ b/graph_weather/data/regional_dataset.py
@@ -2,8 +2,8 @@
 
 Each sample is a bounding box at a random location and timestep, drawn from the
 regular lat/lon IFS ``hres_analysis`` grid. It yields a ``(features, lat_lons,
-target)`` tuple shaped for ``RegionalForecaster.forward``: a region that can move
-anywhere on the globe per sample (Issue #3).
+target, global_context)`` tuple shaped for ``RegionalForecaster.forward``: a
+region that can move anywhere on the globe per sample (Issue #3).
 """
 
 import numpy as np
@@ -85,6 +85,13 @@ class RegionalDataset(Dataset):
         seed: Base seed; sample ``idx`` uses ``seed + idx`` so boxes move per idx.
         mean: Per-variable means for standardisation.
         std: Per-variable standard deviations for standardisation.
+        global_coarsen: Block-average factor for the coarse global context.
+
+    Note:
+        ``global_context`` is a coarse (block-averaged) low-resolution view of the
+        same IFS field at the same points, returned for the BoundaryNudgingLayer.
+        It is a Phase-1 stand-in: it does NOT yet inject true outside-domain
+        weather, which needs a separate host model or a unified mesh (later).
     """
 
     def __init__(
@@ -97,6 +104,7 @@ class RegionalDataset(Dataset):
         seed: int = 0,
         mean: dict = None,
         std: dict = None,
+        global_coarsen: int = 8,
     ):
         """Open the source grid and record sampling configuration."""
         super().__init__()
@@ -107,6 +115,7 @@ class RegionalDataset(Dataset):
         self.seed = seed
         self.mean = mean if mean is not None else CORE_SURFACE_MEAN
         self.std = std if std is not None else CORE_SURFACE_STD
+        self.global_coarsen = global_coarsen
         self.lat = self.data["latitude"].values
         self.lon = self.data["longitude"].values
 
@@ -139,22 +148,50 @@ class RegionalDataset(Dataset):
             flat_lon[pick],
         )
 
-    def _extract(self, t, lat_idx, lon_idx, iy, ix):
-        """Stack standardised variables at the sampled points for timestep t."""
+    def _coarsen(self, arr):
+        """Block-average a 2D crop into kxk blocks, broadcast back to its shape."""
+        k = self.global_coarsen
+        if k <= 1:
+            return arr
+        ny, nx = arr.shape
+        out = np.empty_like(arr)
+        for by in range(0, ny, k):
+            for bx in range(0, nx, k):
+                block = arr[by : by + k, bx : bx + k]
+                out[by : by + k, bx : bx + k] = (
+                    np.nanmean(block) if np.isfinite(block).any() else np.nan
+                )
+        return out
+
+    def _extract(self, t, lat_idx, lon_idx, iy, ix, coarse=False):
+        """Stack standardised variables at the sampled points for timestep t.
+
+        When ``coarse`` is set, each variable's crop is block-averaged first, so
+        the sampled values form a low-resolution (global-context) view.
+        """
         cols = []
         for v in self.variables:
             arr = self.data[v].isel(time=t, latitude=lat_idx, longitude=lon_idx).values
+            if coarse:
+                arr = self._coarsen(arr)
             col = (arr[iy, ix] - self.mean[v]) / self.std[v]
             cols.append(col)
         feat = np.stack(cols, axis=-1).astype(np.float32)
         return np.nan_to_num(feat, nan=0.0)
 
     def __getitem__(self, idx):
-        """Return (features [N, F], lat_lons list, target [N, F]) for one box."""
+        """Return (features, lat_lons, target, global_context) for one box.
+
+        features/target/global_context are [N, F]; lat_lons is a list of
+        (lat, lon) tuples. global_context is the coarse view at the same points.
+        """
         rng = np.random.default_rng(self.seed + idx)
         lat_idx, lon_idx, iy, ix, plat, plon = self._sample_box(rng)
 
         features = torch.from_numpy(self._extract(idx, lat_idx, lon_idx, iy, ix))
         target = torch.from_numpy(self._extract(idx + 1, lat_idx, lon_idx, iy, ix))
+        global_context = torch.from_numpy(
+            self._extract(idx, lat_idx, lon_idx, iy, ix, coarse=True)
+        )
         lat_lons = [(float(a), float(b)) for a, b in zip(plat, plon)]
-        return features, lat_lons, target
+        return features, lat_lons, target, global_context

--- a/tests/test_regional_dataset.py
+++ b/tests/test_regional_dataset.py
@@ -26,11 +26,12 @@ def _dataset(**kwargs):
 
 
 def test_sample_shapes():
-    """Features and target are [N, F]; lat_lons has N entries; F == len(CORE)."""
-    features, lat_lons, target = _dataset()[0]
+    """features, target, global_context are [N, F]; lat_lons has N entries."""
+    features, lat_lons, target, global_context = _dataset()[0]
     n = features.shape[0]
     assert features.shape == (n, len(CORE_SURFACE))
     assert target.shape == (n, len(CORE_SURFACE))
+    assert global_context.shape == (n, len(CORE_SURFACE))
     assert len(lat_lons) == n
 
 
@@ -41,14 +42,14 @@ def test_len_is_time_minus_one():
 
 def test_lat_lons_is_list_of_tuples():
     """lat_lons must be a plain Python list of (lat, lon) for the graph builder."""
-    _, lat_lons, _ = _dataset()[0]
+    _, lat_lons, _, _ = _dataset()[0]
     assert isinstance(lat_lons, list)
     assert isinstance(lat_lons[0], tuple) and len(lat_lons[0]) == 2
 
 
 def test_feeds_regional_forecaster():
     """Loader output drives RegionalForecaster with aux_dim=0 and no shape error."""
-    features, lat_lons, _ = _dataset()[0]
+    features, lat_lons, _, _ = _dataset()[0]
     model = RegionalForecasterConfig(
         feature_dim=len(CORE_SURFACE), aux_dim=0, node_dim=32, edge_dim=32, num_blocks=2
     ).build()
@@ -59,8 +60,8 @@ def test_feeds_regional_forecaster():
 def test_movable_centers():
     """Different idx samples a different bounding box location."""
     ds = _dataset()
-    _, ll0, _ = ds[0]
-    _, ll1, _ = ds[1]
+    _, ll0, _, _ = ds[0]
+    _, ll1, _, _ = ds[1]
     assert ll0 != ll1
 
 
@@ -68,7 +69,7 @@ def test_points_in_domain():
     """Sampled coordinates stay within the grid extent for every sample."""
     ds = _dataset()
     for i in range(len(ds)):
-        _, lat_lons, _ = ds[i]
+        _, lat_lons, _, _ = ds[i]
         lats = [a for a, _ in lat_lons]
         lons = [b for _, b in lat_lons]
         assert min(lats) >= -80.0 and max(lats) <= 80.0
@@ -77,7 +78,7 @@ def test_points_in_domain():
 
 def test_max_points_cap():
     """Number of points never exceeds max_points."""
-    features, _, _ = RegionalDataset(dataset=_synthetic_ds(), extent_deg=60.0, max_points=20)[0]
+    features, _, _, _ = RegionalDataset(dataset=_synthetic_ds(), extent_deg=60.0, max_points=20)[0]
     assert features.shape[0] <= 20
 
 
@@ -85,6 +86,37 @@ def test_nan_filled():
     """A fully-NaN variable produces no NaN in the output (fill after normalize)."""
     ds_syn = _synthetic_ds()
     ds_syn["total_cloud_cover"][:] = np.nan
-    features, _, target = RegionalDataset(dataset=ds_syn, extent_deg=40.0, max_points=100)[0]
+    features, _, target, global_context = RegionalDataset(
+        dataset=ds_syn, extent_deg=40.0, max_points=100
+    )[0]
     assert not torch.isnan(features).any()
     assert not torch.isnan(target).any()
+    assert not torch.isnan(global_context).any()
+
+
+def test_global_context_is_coarser():
+    """global_context differs from features (blurring did something)."""
+    features, _, _, global_context = _dataset(global_coarsen=8)[0]
+    assert global_context.shape == features.shape
+    assert not torch.equal(global_context, features)
+
+
+def test_coarsen_one_is_identity():
+    """global_coarsen=1 leaves the field unchanged, so context == features."""
+    features, _, _, global_context = _dataset(global_coarsen=1)[0]
+    assert torch.allclose(global_context, features)
+
+
+def test_global_context_feeds_nudging():
+    """global_context drives RegionalForecaster with nudging enabled, no shape error."""
+    features, lat_lons, _, global_context = _dataset()[0]
+    model = RegionalForecasterConfig(
+        feature_dim=len(CORE_SURFACE),
+        aux_dim=0,
+        node_dim=32,
+        edge_dim=32,
+        num_blocks=2,
+        enable_nudging=True,
+    ).build()
+    out = model(features.unsqueeze(0), lat_lons, global_context=global_context.unsqueeze(0))
+    assert out.shape == (1, features.shape[0], len(CORE_SURFACE))


### PR DESCRIPTION
# Pull Request

## Description

`RegionalDataset` now returns a fourth item, `global_context`, so the data side can feed `BoundaryNudgingLayer` (#223). Each sample is now `(features, lat_lons, target, global_context)`.

`global_context` is a coarse (block-averaged) low-resolution view of the same IFS field at the same points - shaped `[N, F]` like `features`, so the nudging layer can blend them per point. A `global_coarsen` knob (default 8) controls the block size.

Honest scope: this is a Phase-1 stand-in. It's a coarse view of the *same* IFS data, not a separate host model and not true outside-the-domain weather , it gives the nudging layer the right ingredient in the right shape so the full chain runs. Real boundary forcing (a separate global/host model, or the unified stretched/refined mesh) is later work. Documented as such in the code.

This completes the Phase-1 dataset side: the loader now connects to the merged nudging layer.

Related to #3

## How Has This Been Tested?

Extended `tests/test_regional_dataset.py` (synthetic in-memory grid, no cloud):
- `global_context` has the same shape as `features`
- it differs from `features` when coarsened (blurring took effect)
- `global_coarsen=1` is identity (context == features) : sanity check
- it feeds `RegionalForecaster(enable_nudging=True)` via `global_context=...` with no shape error (loader ↔ nudging loop closes)
- existing shape / movable / in-domain / max_points / NaN-fill tests updated to the 4-tuple

Commands:
- `pytest tests/test_regional_dataset.py -v` → 11 passed
- `pytest tests/test_regional_dataset.py tests/test_regional_forecast.py tests/test_dynamic_graph_builder.py -q` → 30 passed
- `ruff check ...` → clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
