### PR TITLE
feat: add variable-resolution H3 mesh builder

### DIFF
--- a/graph_weather/models/layers/stretched_mesh.py
+++ b/graph_weather/models/layers/stretched_mesh.py
@@ -1,0 +1,54 @@
+"""Build a variable-resolution ("stretched") H3 mesh.
+
+The mesh is coarse over the whole globe and fine over a chosen bounding box, with no
+explicit boundary between the two regions. This is the single-mesh alternative to the
+dual-mesh-plus-nudging approach: one set of H3 cells whose resolution varies by location.
+"""
+
+import h3
+
+
+def build_variable_resolution_mesh(
+    bbox: tuple[float, float, float, float],
+    coarse_res: int,
+    fine_res: int,
+) -> list[str]:
+    """Build a globe-covering H3 mesh that is refined over a bounding box.
+
+    The globe is tiled at ``coarse_res``. Every coarse cell whose centre falls inside
+    ``bbox`` is replaced by its descendants at ``fine_res``. The result tiles the globe
+    exactly once: it is gap-free and has no overlapping (parent + child) cells.
+
+    Because cell selection uses centroid containment, ``coarse_res`` must be fine enough
+    that at least one coarse cell centre lands inside ``bbox``; otherwise no refinement
+    happens and the mesh is uniformly coarse.
+
+    Args:
+        bbox: Region to refine as ``(lat_min, lat_max, lon_min, lon_max)`` in degrees.
+        coarse_res: H3 resolution used outside the region.
+        fine_res: H3 resolution used inside the region. Must be greater than ``coarse_res``.
+
+    Returns:
+        H3 cell indices (string form) for the mixed-resolution mesh, sorted for
+        reproducibility.
+
+    Raises:
+        ValueError: If ``fine_res`` is not greater than ``coarse_res``.
+    """
+    if fine_res <= coarse_res:
+        raise ValueError(f"fine_res ({fine_res}) must be greater than coarse_res ({coarse_res})")
+
+    lat_min, lat_max, lon_min, lon_max = bbox
+    region_polygon = h3.LatLngPoly(
+        [(lat_min, lon_min), (lat_max, lon_min), (lat_max, lon_max), (lat_min, lon_max)]
+    )
+    region_coarse = set(h3.polygon_to_cells(region_polygon, coarse_res))
+
+    coarse_globe = set(h3.uncompact_cells(h3.get_res0_cells(), coarse_res))
+
+    fine_cells: set[str] = set()
+    for cell in region_coarse:
+        fine_cells.update(h3.cell_to_children(cell, fine_res))
+
+    mesh = (coarse_globe - region_coarse) | fine_cells
+    return sorted(mesh)

--- a/tests/test_stretched_mesh.py
+++ b/tests/test_stretched_mesh.py
@@ -1,0 +1,71 @@
+"""Tests for the variable-resolution (stretched) H3 mesh builder."""
+
+import h3
+import pytest
+
+from graph_weather.models.layers.stretched_mesh import build_variable_resolution_mesh
+
+# Bounding box (lat_min, lat_max, lon_min, lon_max) over the UK, large enough that
+# polygon_to_cells finds region cells at coarse_res=2.
+BBOX = (50.0, 55.0, -2.0, 3.0)
+
+
+def test_mesh_size_and_no_duplicates():
+    """Mesh replaces region coarse cells with their fine children, no duplicates."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+
+    # globe@res2 = 5882, region@res2 = 2, each res2 cell has 49 res4 children:
+    # 5882 - 2 + 2 * 49 = 5978.
+    assert len(mesh) == 5978
+    assert len(set(mesh)) == 5978
+
+
+def test_only_two_resolutions_present():
+    """Every cell is at either the coarse or the fine resolution."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+
+    resolutions = {h3.get_resolution(cell) for cell in mesh}
+    assert resolutions == {2, 4}
+
+
+def test_region_refined_to_fine():
+    """A point inside the bbox lands in a fine cell that is in the mesh."""
+    mesh = set(build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4))
+
+    inside_fine = h3.latlng_to_cell(52.5, 0.5, 4)
+    assert inside_fine in mesh
+
+    # The coarse cells covering the region must not appear (no parent + child overlap).
+    region_coarse = h3.polygon_to_cells(h3.LatLngPoly([(50, -2), (55, -2), (55, 3), (50, 3)]), 2)
+    assert all(cell not in mesh for cell in region_coarse)
+
+
+def test_outside_region_stays_coarse():
+    """A point far from the bbox lands in a coarse cell that is in the mesh."""
+    mesh = set(build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4))
+
+    outside_coarse = h3.latlng_to_cell(-40.0, 150.0, 2)
+    assert outside_coarse in mesh
+
+
+def test_exact_global_coverage():
+    """Mesh tiles the whole globe exactly once when expanded to the fine resolution."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+
+    mesh_fine = list(h3.uncompact_cells(mesh, 4))
+    globe_fine = list(h3.uncompact_cells(h3.uncompact_cells(h3.get_res0_cells(), 2), 4))
+
+    assert len(mesh_fine) == len(set(mesh_fine))  # no overlaps
+    assert set(mesh_fine) == set(globe_fine)  # complete, gap-free coverage
+
+
+def test_returns_sorted_for_reproducibility():
+    """Cells come back in sorted order so the mesh is deterministic across runs."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    assert mesh == sorted(mesh)
+
+
+def test_fine_res_must_exceed_coarse_res():
+    """A fine resolution that is not finer than the coarse one is rejected."""
+    with pytest.raises(ValueError):
+        build_variable_resolution_mesh(BBOX, coarse_res=4, fine_res=4)


### PR DESCRIPTION
# Pull Request

## Description

Adds `build_variable_resolution_mesh`, the first piece of the stretched-grid regional model. It tiles the globe at a coarse H3 resolution, then refines every coarse cell whose centre falls inside a bounding box down to a finer resolution, replacing each coarse region cell with its fine children.

The result is one mesh whose resolution varies by location - fine over the region, coarse everywhere else - with no explicit boundary between the two. This is the single-mesh alternative to the dual-mesh-plus-nudging approach. Approach confirmed on #3.

Pure function, no model or training changes yet. The latent graph and embedding wiring come in later PRs.

Note: region selection uses centroid containment (`polygon_to_cells`), so the coarse resolution has to be fine enough that at least one coarse cell centre lands in the box; otherwise nothing gets refined. Documented as a precondition, and `fine_res <= coarse_res` raises `ValueError`.

Related to #3

## How Has This Been Tested?

Added `tests/test_stretched_mesh.py` - plain pytest, runs entirely on h3, no network:
- mesh size and uniqueness (coarse globe minus region plus fine children)
- only the two expected resolutions present
- a point inside the box lands in a fine cell; the coarse region parents are absent (no parent + child overlap)
- a point far outside stays coarse
- expanded to the fine resolution the mesh tiles the globe exactly once (gap-free,no overlap)
- cells returned sorted for reproducibility
- fine_res not greater than coarse_res raises

Commands:
- `pytest tests/test_stretched_mesh.py -q` -> 7 passed
- `ruff check graph_weather/models/layers/stretched_mesh.py tests/test_stretched_mesh.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
