### PR TITLE
feat: add variable-resolution latent graph builder

### DIFF
--- a/graph_weather/models/layers/stretched_latent_graph.py
+++ b/graph_weather/models/layers/stretched_latent_graph.py
@@ -1,0 +1,61 @@
+"""Build a message-passing graph over a variable-resolution ("stretched") H3 mesh.
+
+The mesh from ``build_variable_resolution_mesh`` mixes two H3 resolutions: coarse cells
+over the globe and fine cells over a region. Same-resolution neighbours are found with
+``grid_disk``, but that never crosses the coarse/fine seam, so the fine region would be a
+disconnected island. This module adds the missing seam edges: each fine cell is joined to
+the coarse cells bordering its coarse ancestor, found through ``cell_to_parent``.
+"""
+
+from typing import List
+
+import h3
+import numpy as np
+import torch
+from torch_geometric.data import Data
+
+
+def build_variable_resolution_latent_graph(cells: List[str]) -> Data:
+    """Wire a latent graph over a mixed-resolution H3 cell set.
+
+    Args:
+        cells: H3 cell indices from a variable-resolution mesh, mixing a coarse globe
+            resolution with a finer region resolution.
+
+    Returns:
+        A ``torch_geometric`` ``Data`` with ``edge_index`` [2, E] and ``edge_attr`` [E, 2]
+        holding ``[sin(d), cos(d)]`` of the great-circle distance between cell centres.
+        Nodes are the cells in sorted order; edges are bidirectional. Each cell links to
+        its same-resolution ring neighbours, and every fine cell additionally links to the
+        coarse cells adjacent to its coarse ancestor, stitching the seam closed.
+    """
+    cells = sorted(cells)
+    idx = {cell: i for i, cell in enumerate(cells)}
+    cell_set = set(cells)
+    coarse_res = min(h3.get_resolution(cell) for cell in cells)
+
+    edges = set()
+    for cell in cells:
+        source = idx[cell]
+        for neighbor in h3.grid_disk(cell, 1):
+            if neighbor != cell and neighbor in idx:
+                edges.add((source, idx[neighbor]))
+        if h3.get_resolution(cell) > coarse_res:
+            parent = h3.cell_to_parent(cell, coarse_res)
+            for coarse in h3.grid_disk(parent, 1):
+                if coarse in cell_set and h3.get_resolution(coarse) == coarse_res:
+                    edges.add((source, idx[coarse]))
+                    edges.add((idx[coarse], source))
+
+    sources, targets, attrs = [], [], []
+    for source, target in sorted(edges):
+        dist = h3.great_circle_distance(
+            h3.cell_to_latlng(cells[source]), h3.cell_to_latlng(cells[target]), unit="rads"
+        )
+        sources.append(source)
+        targets.append(target)
+        attrs.append([np.sin(dist), np.cos(dist)])
+
+    edge_index = torch.tensor([sources, targets], dtype=torch.long)
+    edge_attr = torch.tensor(attrs, dtype=torch.float)
+    return Data(edge_index=edge_index, edge_attr=edge_attr)

--- a/tests/test_stretched_latent_graph.py
+++ b/tests/test_stretched_latent_graph.py
@@ -1,0 +1,97 @@
+"""Tests for the variable-resolution latent graph builder."""
+
+import h3
+import torch
+
+from graph_weather.models.layers.stretched_latent_graph import (
+    build_variable_resolution_latent_graph,
+)
+from graph_weather.models.layers.stretched_mesh import build_variable_resolution_mesh
+
+BBOX = (50.0, 55.0, -2.0, 3.0)
+COARSE_RES = 2
+FINE_RES = 4
+
+
+def _mesh():
+    """A real coarse-globe-plus-fine-region mesh to wire into a graph."""
+    return build_variable_resolution_mesh(BBOX, COARSE_RES, FINE_RES)
+
+
+def _edge_pairs(graph):
+    """Directed (source, target) index pairs from a graph's edge_index."""
+    return list(zip(graph.edge_index[0].tolist(), graph.edge_index[1].tolist()))
+
+
+def test_seam_has_cross_resolution_edges():
+    """At least one edge joins a coarse cell to a fine cell across the seam."""
+    cells = _mesh()
+    graph = build_variable_resolution_latent_graph(cells)
+    res = [h3.get_resolution(c) for c in sorted(cells)]
+    cross = [(s, t) for s, t in _edge_pairs(graph) if res[s] != res[t]]
+    assert len(cross) > 0
+
+
+def test_graph_is_connected():
+    """Every node reaches every other: the fine region is not a sealed island."""
+    cells = _mesh()
+    graph = build_variable_resolution_latent_graph(cells)
+    n = len(cells)
+    parent = list(range(n))
+
+    def find(x):
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    for s, t in _edge_pairs(graph):
+        parent[find(s)] = find(t)
+    roots = {find(i) for i in range(n)}
+    assert len(roots) == 1
+
+
+def test_interior_same_resolution_connected():
+    """Two adjacent fine cells inside the region share an edge."""
+    cells = _mesh()
+    sorted_cells = sorted(cells)
+    idx = {c: i for i, c in enumerate(sorted_cells)}
+    fine = [c for c in sorted_cells if h3.get_resolution(c) == FINE_RES]
+    pair = None
+    for c in fine:
+        for nb in h3.grid_disk(c, 1):
+            if nb != c and nb in idx and h3.get_resolution(nb) == FINE_RES:
+                pair = (idx[c], idx[nb])
+                break
+        if pair:
+            break
+    graph = build_variable_resolution_latent_graph(cells)
+    assert pair in _edge_pairs(graph)
+
+
+def test_no_self_loops():
+    """No cell has an edge to itself."""
+    graph = build_variable_resolution_latent_graph(_mesh())
+    assert all(s != t for s, t in _edge_pairs(graph))
+
+
+def test_no_duplicate_edges():
+    """Each directed edge appears exactly once."""
+    graph = build_variable_resolution_latent_graph(_mesh())
+    pairs = _edge_pairs(graph)
+    assert len(pairs) == len(set(pairs))
+
+
+def test_node_count_matches_cells():
+    """edge_index references exactly the supplied cells, no more."""
+    cells = _mesh()
+    graph = build_variable_resolution_latent_graph(cells)
+    assert int(graph.edge_index.max()) < len(cells)
+
+
+def test_edge_attr_on_unit_circle():
+    """edge_attr is [E, 2] sin/cos pairs lying on the unit circle."""
+    graph = build_variable_resolution_latent_graph(_mesh())
+    assert graph.edge_attr.shape == (graph.edge_index.shape[1], 2)
+    norms = graph.edge_attr[:, 0] ** 2 + graph.edge_attr[:, 1] ** 2
+    assert torch.allclose(norms, torch.ones_like(norms), atol=1e-5)


### PR DESCRIPTION
# Pull Request

## Description

Builds on #226. `build_variable_resolution_mesh` returns a mixed-resolution cell set, coarse over the globe and fine over the region, and this PR turns that set into the latent graph the processor message-passes over.

The problem is the seam between the two resolutions. Same-resolution neighbours come from `grid_disk`, but that never crosses from a coarse cell to a fine one, so on its own the fine region is a disconnected island and no information flows in or out. Each fine cell is therefore also linked to the coarse cells bordering its coarse ancestor, found with `cell_to_parent` and then `grid_disk` on that parent, keeping the coarse cells that are actually present in the mesh. Edges are bidirectional and carry `[sin d, cos d]` of the great-circle distance between cell centres, the same edge feature the single-resolution builder already uses.

Pure function: it takes a cell list and returns a `torch_geometric` `Data`. No model or training changes yet - wiring it into the forecaster and resizing the embedding table come in later PRs.

Related to #3

## How Has This Been Tested?

Added `tests/test_stretched_latent_graph.py` - plain pytest, runs entirely on h3, no network:
- at least one edge joins a coarse cell to a fine cell, so the seam is bridged
- union-find over every edge gives a single connected component, so the fine region is not an island
- two adjacent fine interior cells still share an edge (same-resolution case intact)
- no self-loops
- no duplicate edges
- edge indices reference exactly the supplied cells
- `edge_attr` is `[E, 2]` with each row on the unit circle

Commands:
- `pytest tests/test_stretched_latent_graph.py -q` -> 7 passed
- `ruff check graph_weather/models/layers/stretched_latent_graph.py tests/test_stretched_latent_graph.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
