### PR TITLE
feat: add point assignment for variable-resolution H3 mesh

### DIFF
--- a/graph_weather/models/layers/stretched_mesh.py
+++ b/graph_weather/models/layers/stretched_mesh.py
@@ -52,3 +52,34 @@ def build_variable_resolution_mesh(
 
     mesh = (coarse_globe - region_coarse) | fine_cells
     return sorted(mesh)
+
+
+def assign_points_to_mesh(
+    lat_lons: list[tuple[float, float]],
+    mesh: list[str],
+    coarse_res: int,
+    fine_res: int,
+) -> list[str]:
+    """Assign each lat/lon point to the cell it belongs to in a variable-resolution mesh.
+
+    A point inside the refined region lands on its fine cell; a point outside lands on its
+    coarse cell. The fine cell is tried first and used when it is present in ``mesh``,
+    otherwise the point's coarse cell is used. Because the mesh refines whole coarse cells
+    into all of their children, the fine cell is present exactly when the point sits in the
+    region, so every returned cell is a member of ``mesh`` and contains its point.
+
+    Args:
+        lat_lons: Observation points as ``(lat, lon)`` in degrees.
+        mesh: H3 cell indices of the mesh, e.g. from ``build_variable_resolution_mesh``.
+        coarse_res: H3 resolution used outside the refined region.
+        fine_res: H3 resolution used inside the refined region.
+
+    Returns:
+        One H3 cell index per input point, in the same order.
+    """
+    mesh_set = set(mesh)
+    assigned = []
+    for lat, lon in lat_lons:
+        fine = h3.latlng_to_cell(lat, lon, fine_res)
+        assigned.append(fine if fine in mesh_set else h3.latlng_to_cell(lat, lon, coarse_res))
+    return assigned

--- a/tests/test_stretched_mesh.py
+++ b/tests/test_stretched_mesh.py
@@ -3,7 +3,10 @@
 import h3
 import pytest
 
-from graph_weather.models.layers.stretched_mesh import build_variable_resolution_mesh
+from graph_weather.models.layers.stretched_mesh import (
+    assign_points_to_mesh,
+    build_variable_resolution_mesh,
+)
 
 # Bounding box (lat_min, lat_max, lon_min, lon_max) over the UK, large enough that
 # polygon_to_cells finds region cells at coarse_res=2.
@@ -69,3 +72,45 @@ def test_fine_res_must_exceed_coarse_res():
     """A fine resolution that is not finer than the coarse one is rejected."""
     with pytest.raises(ValueError):
         build_variable_resolution_mesh(BBOX, coarse_res=4, fine_res=4)
+
+
+def test_assignment_one_cell_per_point():
+    """Each input point gets exactly one assigned cell, order preserved."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    points = [(52.5, 0.5), (-40.0, 150.0), (0.0, 0.0)]
+    assigned = assign_points_to_mesh(points, mesh, coarse_res=2, fine_res=4)
+    assert len(assigned) == len(points)
+
+
+def test_point_in_region_assigned_fine_cell():
+    """A point inside the refined region is assigned its fine cell."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    assigned = assign_points_to_mesh([(52.5, 0.5)], mesh, coarse_res=2, fine_res=4)
+    assert h3.get_resolution(assigned[0]) == 4
+    assert assigned[0] == h3.latlng_to_cell(52.5, 0.5, 4)
+
+
+def test_point_outside_region_assigned_coarse_cell():
+    """A point outside the region is assigned its coarse cell."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    assigned = assign_points_to_mesh([(-40.0, 150.0)], mesh, coarse_res=2, fine_res=4)
+    assert h3.get_resolution(assigned[0]) == 2
+    assert assigned[0] == h3.latlng_to_cell(-40.0, 150.0, 2)
+
+
+def test_every_assigned_cell_is_in_mesh():
+    """Every assigned cell is a member of the mesh (fine inside, coarse outside)."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    points = [(52.5, 0.5), (53.0, 1.0), (-40.0, 150.0), (0.0, 0.0), (80.0, -100.0)]
+    assigned = assign_points_to_mesh(points, mesh, coarse_res=2, fine_res=4)
+    mesh_set = set(mesh)
+    assert all(cell in mesh_set for cell in assigned)
+
+
+def test_assigned_cell_contains_its_point():
+    """The assigned cell is the H3 cell that actually contains the point."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    points = [(52.5, 0.5), (-40.0, 150.0), (0.0, 0.0), (80.0, -100.0)]
+    assigned = assign_points_to_mesh(points, mesh, coarse_res=2, fine_res=4)
+    for (lat, lon), cell in zip(points, assigned):
+        assert h3.latlng_to_cell(lat, lon, h3.get_resolution(cell)) == cell


### PR DESCRIPTION
# Pull Request

## Description

Builds on #226. The stretched mesh mixes coarse and fine H3 cells, so to use it each observation point has to be attached to the right cell: fine where the mesh is refined, coarse elsewhere. This adds `assign_points_to_mesh`, which does that.

For each point it computes the fine cell and uses it when that cell is in the mesh, otherwise it falls back to the point's coarse cell. Because the mesh refines whole coarse cells into all of their children, a point's fine cell is present exactly when the point sits in the refined region, so every returned cell is in the mesh and contains its point. It keeps the containment convention the single-resolution builder already uses (`latlng_to_cell`), just choosing the resolution per point.

Pure function, no model or training changes. The encoder and decoder graphs and the embedding table that consume these assignments come in a later PR.

Related to #3

## How Has This Been Tested?

Added tests to `tests/test_stretched_mesh.py` - plain pytest, runs entirely on h3, no network:
- one assigned cell per point, order preserved
- a point inside the region gets its fine cell
- a point outside the region gets its coarse cell
- every assigned cell is a member of the mesh
- the assigned cell is the one that actually contains the point

Commands:
- `pytest tests/test_stretched_mesh.py -q` -> 12 passed
- `ruff check graph_weather/models/layers/stretched_mesh.py tests/test_stretched_mesh.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
