### PR TITLE
feat: add mixed-resolution embedding index for stretched mesh

### DIFF
--- a/graph_weather/models/layers/stretched_mesh.py
+++ b/graph_weather/models/layers/stretched_mesh.py
@@ -83,3 +83,42 @@ def assign_points_to_mesh(
         fine = h3.latlng_to_cell(lat, lon, fine_res)
         assigned.append(fine if fine in mesh_set else h3.latlng_to_cell(lat, lon, coarse_res))
     return assigned
+
+
+def _global_row_map(res: int) -> dict[str, int]:
+    """Map every H3 cell at ``res`` to its row in the sorted global cell set."""
+    return {cell: i for i, cell in enumerate(sorted(h3.uncompact_cells(h3.get_res0_cells(), res)))}
+
+
+def mixed_resolution_embedding_indices(
+    cells: list[str],
+    coarse_res: int,
+    fine_res: int,
+) -> list[tuple[int, int]]:
+    """Map each mesh cell to its row in a global, per-resolution embedding table.
+
+    A stretched mesh mixes coarse and fine cells, so one table indexed by a single
+    resolution no longer fits. Each cell is placed in the table for its own resolution, at
+    the row given by its position in ``sorted(uncompact_cells(get_res0_cells(), res))`` - the
+    same global numbering ``DynamicGraphBuilder`` uses. Because the row depends only on the
+    cell, a location keeps its learned vector as the refined region moves rather than
+    relearning it.
+
+    Args:
+        cells: H3 cell indices of the mesh, e.g. from ``build_variable_resolution_mesh``.
+        coarse_res: H3 resolution used outside the refined region.
+        fine_res: H3 resolution used inside the refined region.
+
+    Returns:
+        One ``(resolution, row)`` per input cell, in the same order. ``row`` indexes the
+        global table for that cell's resolution.
+    """
+    coarse_rows = _global_row_map(coarse_res)
+    fine_rows = _global_row_map(fine_res)
+
+    indices = []
+    for cell in cells:
+        res = h3.get_resolution(cell)
+        row = fine_rows[cell] if res == fine_res else coarse_rows[cell]
+        indices.append((res, row))
+    return indices

--- a/tests/test_stretched_mesh.py
+++ b/tests/test_stretched_mesh.py
@@ -6,6 +6,7 @@ import pytest
 from graph_weather.models.layers.stretched_mesh import (
     assign_points_to_mesh,
     build_variable_resolution_mesh,
+    mixed_resolution_embedding_indices,
 )
 
 # Bounding box (lat_min, lat_max, lon_min, lon_max) over the UK, large enough that
@@ -114,3 +115,64 @@ def test_assigned_cell_contains_its_point():
     assigned = assign_points_to_mesh(points, mesh, coarse_res=2, fine_res=4)
     for (lat, lon), cell in zip(points, assigned):
         assert h3.latlng_to_cell(lat, lon, h3.get_resolution(cell)) == cell
+
+
+def test_index_one_entry_per_cell_with_matching_resolution():
+    """Each mesh cell gets one (resolution, row) entry, resolution matching the cell."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    indices = mixed_resolution_embedding_indices(mesh, coarse_res=2, fine_res=4)
+
+    assert len(indices) == len(mesh)
+    for cell, (res, _row) in zip(mesh, indices):
+        assert res == h3.get_resolution(cell)
+
+
+def test_index_row_within_resolution_table():
+    """Every row sits inside its own resolution's global table range."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    indices = mixed_resolution_embedding_indices(mesh, coarse_res=2, fine_res=4)
+
+    for res, row in indices:
+        assert 0 <= row < h3.get_num_cells(res)
+
+
+def test_index_matches_global_cell_numbering():
+    """A row equals the cell's position in the sorted global cell set at its resolution."""
+    mesh = build_variable_resolution_mesh(BBOX, coarse_res=2, fine_res=4)
+    indices = mixed_resolution_embedding_indices(mesh, coarse_res=2, fine_res=4)
+
+    coarse_globe = sorted(h3.uncompact_cells(h3.get_res0_cells(), 2))
+    fine_globe = sorted(h3.uncompact_cells(h3.get_res0_cells(), 4))
+    coarse_map = {c: i for i, c in enumerate(coarse_globe)}
+    fine_map = {c: i for i, c in enumerate(fine_globe)}
+
+    for cell, (res, row) in zip(mesh, indices):
+        expected = coarse_map[cell] if res == 2 else fine_map[cell]
+        assert row == expected
+
+
+def test_coarse_index_persists_when_region_moves():
+    """A coarse cell keeps its row when the refined region moves elsewhere."""
+    uk = build_variable_resolution_mesh((50.0, 55.0, -2.0, 3.0), coarse_res=2, fine_res=4)
+    japan = build_variable_resolution_mesh((30.0, 40.0, 135.0, 145.0), coarse_res=2, fine_res=4)
+
+    uk_idx = dict(zip(uk, mixed_resolution_embedding_indices(uk, 2, 4)))
+    japan_idx = dict(zip(japan, mixed_resolution_embedding_indices(japan, 2, 4)))
+
+    common_coarse = [c for c in set(uk) & set(japan) if h3.get_resolution(c) == 2]
+    assert common_coarse
+    for cell in common_coarse:
+        assert uk_idx[cell] == japan_idx[cell]
+
+
+def test_fine_index_persists_across_different_regions():
+    """A fine cell shared by two meshes keeps the same row in both."""
+    small = build_variable_resolution_mesh((50.0, 55.0, -2.0, 3.0), coarse_res=2, fine_res=4)
+    large = build_variable_resolution_mesh((48.0, 57.0, -4.0, 5.0), coarse_res=2, fine_res=4)
+
+    fine_cell = h3.latlng_to_cell(52.5, 0.5, 4)
+    small_idx = dict(zip(small, mixed_resolution_embedding_indices(small, 2, 4)))
+    large_idx = dict(zip(large, mixed_resolution_embedding_indices(large, 2, 4)))
+
+    assert fine_cell in small_idx and fine_cell in large_idx
+    assert small_idx[fine_cell] == large_idx[fine_cell]


### PR DESCRIPTION
# Pull Request

## Description

Adds `mixed_resolution_embedding_indices`, the piece that lets a stretched mesh use a learnable embedding per H3 cell. On a single-resolution mesh the model keeps one embedding table indexed by cell, but a stretched mesh mixes coarse and fine cells, so one table indexed by a single resolution no longer fits.

This maps each mesh cell to a `(resolution, row)`. The row is the cell's position in `sorted(uncompact_cells(get_res0_cells(), res))`, the same global numbering `DynamicGraphBuilder` already uses. Because the row depends only on the cell, a location keeps the same row no matter which mesh it lands in, so a moving region reuses the vector it already learned for that spot instead of relearning it after every move.

Pure function, no model or training changes yet. The model wiring that gathers from two per-resolution tables (coarse and fine) using these indices comes in a later PR. This is the third building block for the stretched-grid model, after the mesh builder (#226) and alongside the latent graph (#227) and point assignment (#228).

Related to #3

## How Has This Been Tested?

Added tests to `tests/test_stretched_mesh.py` - plain pytest, runs entirely on h3, no network:
- one `(resolution, row)` per cell, resolution matching the cell
- every row sits inside its own resolution's global table range
- a row equals the cell's position in the sorted global cell set at its resolution
- a coarse cell keeps its row when the refined region moves (UK box vs Japan box)
- a fine cell shared by two different regions keeps the same row in both

Commands:
- `pytest tests/test_stretched_mesh.py -q` -> 12 passed
- `ruff check graph_weather/models/layers/stretched_mesh.py tests/test_stretched_mesh.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
