### PR TITLE
Guard optional data-module imports against missing deps (#179)

### DIFF
--- a/graph_weather/__init__.py
+++ b/graph_weather/__init__.py
@@ -4,6 +4,9 @@ try:
     from .data.nnja_ai import SensorDataset
 except ImportError:
     SensorDataset = None
-from .data.weather_station_reader import WeatherStationReader
+try:
+    from .data.weather_station_reader import WeatherStationReader
+except ImportError:
+    WeatherStationReader = None
 from .models.analysis import GraphWeatherAssimilator
 from .models.forecast import GraphWeatherForecaster

--- a/graph_weather/data/__init__.py
+++ b/graph_weather/data/__init__.py
@@ -1,5 +1,14 @@
 """Dataloaders and data processing utilities"""
 
-from .anemoi_dataloader import AnemoiDataset
-from .nnja_ai import SensorDataset
-from .weather_station_reader import WeatherStationReader
+try:
+    from .anemoi_dataloader import AnemoiDataset
+except ImportError:
+    AnemoiDataset = None
+try:
+    from .nnja_ai import SensorDataset
+except ImportError:
+    SensorDataset = None
+try:
+    from .weather_station_reader import WeatherStationReader
+except ImportError:
+    WeatherStationReader = None

--- a/tests/test_optional_imports.py
+++ b/tests/test_optional_imports.py
@@ -1,0 +1,42 @@
+"""Tests that graph_weather.data degrades gracefully without optional heavy deps.
+
+pandas, xarray, anemoi.datasets, and nnja-ai are not declared dependencies of the
+graph_weather package, so a plain `pip install graph_weather` may not have them
+available. Importing graph_weather.data should not crash in that case - each
+optional dataset class should just fall back to None.
+"""
+
+import builtins
+import importlib
+import sys
+
+import pytest
+
+OPTIONAL_MODULES = ("pandas", "xarray", "anemoi.datasets", "nnja_ai")
+
+
+@pytest.fixture
+def hide_optional_deps(monkeypatch):
+    """Make imports of the optional heavy deps raise ImportError, like a fresh install."""
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name in OPTIONAL_MODULES or any(name.startswith(mod + ".") for mod in OPTIONAL_MODULES):
+            raise ImportError(f"No module named '{name}' (blocked for test)")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    # Drop any already-imported copies so the blocked import actually gets exercised.
+    for name in list(sys.modules):
+        if name.split(".")[0] in ("graph_weather",) or name in OPTIONAL_MODULES:
+            monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def test_data_package_imports_without_optional_deps(hide_optional_deps):
+    """graph_weather.data should import cleanly with pandas/xarray/anemoi/nnja-ai missing."""
+    data = importlib.import_module("graph_weather.data")
+
+    assert data.AnemoiDataset is None
+    assert data.SensorDataset is None
+    assert data.WeatherStationReader is None


### PR DESCRIPTION
Follow-up to #179.

The nnjai_wrapp import from the original report is gone, and `graph_weather/__init__.py` already guards `from .data.nnja_ai import SensorDataset` in a try/except. But `graph_weather/data/__init__.py` still imports `AnemoiDataset`, `SensorDataset`, and `WeatherStationReader` unconditionally, and those pull in pandas, xarray, anemoi.datasets, and nnja-ai at import time. None of those are declared dependencies of graph_weather, so a plain `pip install graph_weather` still crashes on bare `import graph_weather` - just with a different missing-module error depending on what's installed (pandas, then xarray, then an nnja-ai ImportError).

This wraps each of the three imports in `data/__init__.py` in the same try/except pattern already used for `SensorDataset` at the package root, falling back to `None` when the optional dep isn't installed. Also applied the same guard to `WeatherStationReader` in the root `__init__.py`, since it had the same unconditional-import problem.

Added a test that blocks pandas/xarray/anemoi.datasets/nnja_ai at import time and checks `graph_weather.data` still imports with all three classes falling back to `None`.

Verified locally in a clean venv with `pip install --no-deps -e .` and none of the optional deps installed - `import graph_weather` (well, `graph_weather.data` specifically, since I couldn't get a working torch build in this environment) crashed on `pandas` before this change, imports clean after. Couldn't run the full test suite here since I hit the Windows long-path issue installing torch, so I'd appreciate someone running CI on this one rather than trusting my local run alone.
