### PR TITLE
Fix division-by-zero in GraphWeatherForecaster grid mapping for single-axis grids

### DIFF
--- a/graph_weather/models/forecast.py
+++ b/graph_weather/models/forecast.py
@@ -178,17 +178,15 @@ class GraphWeatherForecaster(torch.nn.Module, PyTorchModelHubMixin):
     def _create_grid_mapping(self, unique_lats, unique_lons):
         """Create (row,col) mapping for original node order"""
         self.node_to_grid = []
+        lat_min, lat_max = min(unique_lats), max(unique_lats)
+        lon_min, lon_max = min(unique_lons), max(unique_lons)
+        lat_range = lat_max - lat_min
+        lon_range = lon_max - lon_min
         for lat, lon in self.original_lat_lons:
-            row = int(
-                (lat - min(unique_lats))
-                / (max(unique_lats) - min(unique_lats))
-                * (len(unique_lats) - 1)
-            )
-            col = int(
-                (lon - min(unique_lons))
-                / (max(unique_lons) - min(unique_lons))
-                * (len(unique_lons) - 1)
-            )
+            # A degenerate axis (single unique lat or lon) has no spread to
+            # normalize against, so every node maps to the same row/col.
+            row = int((lat - lat_min) / lat_range * (len(unique_lats) - 1)) if lat_range else 0
+            col = int((lon - lon_min) / lon_range * (len(unique_lons) - 1)) if lon_range else 0
             self.node_to_grid.append((row, col))
 
     def graph_to_grid(self, graph_tensor):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -133,6 +133,31 @@ def test_forecaster():
     assert not torch.isnan(out).any()
 
 
+def test_forecaster_single_lat():
+    # Grid with only one unique latitude used to raise ZeroDivisionError in
+    # _create_grid_mapping, since max(unique_lats) == min(unique_lats).
+    lat_lons = [(45.0, lon) for lon in range(0, 20, 5)]
+    model = GraphWeatherForecaster(lat_lons)
+    assert model.grid_shape == (1, len(lat_lons))
+    assert model.node_to_grid == [(0, i) for i in range(len(lat_lons))]
+
+    features = torch.randn((1, len(lat_lons), 78 + 24))
+    out = model(features)
+    assert not torch.isnan(out).any()
+
+
+def test_forecaster_single_lon():
+    # Same degenerate-axis bug, mirrored onto longitude.
+    lat_lons = [(lat, 10.0) for lat in range(-10, 10, 5)]
+    model = GraphWeatherForecaster(lat_lons)
+    assert model.grid_shape == (len(lat_lons), 1)
+    assert model.node_to_grid == [(i, 0) for i in range(len(lat_lons))]
+
+    features = torch.randn((1, len(lat_lons), 78 + 24))
+    out = model(features)
+    assert not torch.isnan(out).any()
+
+
 def test_assimilator_model():
     obs_lat_lons = []
     for lat in range(-90, 90, 7):


### PR DESCRIPTION
`GraphWeatherForecaster.__init__` calls `_create_grid_mapping` unconditionally, which divides by `max(unique_lats) - min(unique_lats)` and `max(unique_lons) - min(unique_lons)` with no guard for the degenerate case where every node shares one latitude or one longitude. When that happens the range is zero and it raises `ZeroDivisionError` before the model even finishes constructing.

Repro:

```python
from graph_weather.models.forecast import GraphWeatherForecaster

GraphWeatherForecaster(lat_lons=[(45.0, 0.0), (45.0, 10.0)])
# ZeroDivisionError: float division by zero
```

Same thing happens with a single unique longitude, or a single point (both axes degenerate at once).

Fix: when an axis has no spread to normalize against, every node on that axis maps to row/col 0 instead of dividing by zero. Normal 2D grids go through the same math as before, so nothing changes for the common case.

Added two tests, `test_forecaster_single_lat` and `test_forecaster_single_lon`, covering both degenerate axes and confirming the model still runs a forward pass without producing NaNs.

I don't have a GPU/full env set up locally to run the whole suite, so I verified the fixed arithmetic in isolation against a range of inputs (single-lat, single-lon, single-point, and a regular grid checked against the original formula for equivalence) and ran ruff/black against the touched files, both clean.
