### PR TITLE
feat: add stretched-grid regional forecaster

### DIFF
--- a/graph_weather/models/stretched_forecast.py
+++ b/graph_weather/models/stretched_forecast.py
@@ -1,0 +1,253 @@
+"""Stretched-grid regional weather forecaster on a variable-resolution H3 mesh.
+
+This is the single-mesh successor to ``RegionalForecaster``. Instead of one mesh at a single
+resolution plus boundary nudging, it runs encode-process-decode over one mesh that is coarse
+globally and fine over a chosen region. The coarse/fine seam is stitched by the latent graph,
+so surrounding weather flows into the region without an explicit boundary layer. Each cell
+starts from a learned embedding held in a global, per-resolution table, so a moving region
+reuses the vector it already learned for a location.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+import h3
+import numpy as np
+import torch
+import torch.nn as nn
+from torch_geometric.data import Data
+
+from graph_weather.models.layers.graph_net_block import MLP, GraphProcessor
+from graph_weather.models.layers.processor import Processor
+from graph_weather.models.layers.stretched_latent_graph import (
+    build_variable_resolution_latent_graph,
+)
+from graph_weather.models.layers.stretched_mesh import (
+    _global_row_map,
+    assign_points_to_mesh,
+    build_variable_resolution_mesh,
+)
+
+
+@dataclass
+class StretchedForecasterConfig:
+    """Configuration for StretchedForecaster."""
+
+    coarse_res: int = 2
+    fine_res: int = 4
+    feature_dim: int = 78
+    aux_dim: int = 24
+    output_dim: Optional[int] = None
+    node_dim: int = 256
+    edge_dim: int = 256
+    num_blocks: int = 9
+    hidden_dim_processor_node: int = 256
+    hidden_dim_processor_edge: int = 256
+    hidden_layers_processor_node: int = 2
+    hidden_layers_processor_edge: int = 2
+    hidden_dim_decoder: int = 128
+    hidden_layers_decoder: int = 2
+    norm_type: str = "LayerNorm"
+    use_checkpointing: bool = False
+
+    def build(self) -> "StretchedForecaster":
+        """Build StretchedForecaster from this configuration."""
+        return StretchedForecaster(self)
+
+
+class StretchedForecaster(nn.Module):
+    """Regional forecaster over a variable-resolution ("stretched") H3 mesh."""
+
+    def __init__(self, config: StretchedForecasterConfig):
+        """Initialize StretchedForecaster from config."""
+        super().__init__()
+        self.config = config
+        input_dim = config.feature_dim + config.aux_dim
+        output_dim = config.output_dim if config.output_dim is not None else config.feature_dim
+        self.output_dim = output_dim
+
+        # One learned embedding per H3 cell, kept in a global table per resolution (Option A).
+        # forward() gathers the rows for the cells in the current mesh.
+        self.coarse_embeddings = nn.Parameter(
+            torch.zeros(h3.get_num_cells(config.coarse_res), input_dim)
+        )
+        self.fine_embeddings = nn.Parameter(
+            torch.zeros(h3.get_num_cells(config.fine_res), input_dim)
+        )
+
+        # Precompute the global cell->row maps once (mirrors DynamicGraphBuilder), so forward
+        # never rebuilds them. Reusing _global_row_map keeps the numbering identical to
+        # mixed_resolution_embedding_indices, so a cell's row is stable as the region moves.
+        self._coarse_rows = _global_row_map(config.coarse_res)
+        self._fine_rows = _global_row_map(config.fine_res)
+
+        # Encoder: obs + cells through a bipartite GNN.
+        self.node_encoder = MLP(
+            input_dim,
+            config.node_dim,
+            config.hidden_dim_processor_node,
+            config.hidden_layers_processor_node,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.edge_encoder = MLP(
+            2,
+            config.edge_dim,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.encoder_gnn = GraphProcessor(
+            1,
+            config.node_dim,
+            config.edge_dim,
+            config.hidden_dim_processor_node,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_node,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            use_checkpointing=config.use_checkpointing,
+        )
+
+        # Processor: message passing cell-to-cell over the latent graph.
+        self.latent_edge_encoder = MLP(
+            2,
+            config.edge_dim,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.processor = Processor(
+            input_dim=config.node_dim,
+            edge_dim=config.edge_dim,
+            num_blocks=config.num_blocks,
+            hidden_dim_processor_edge=config.hidden_dim_processor_edge,
+            hidden_layers_processor_node=config.hidden_layers_processor_node,
+            hidden_dim_processor_node=config.hidden_dim_processor_node,
+            hidden_layers_processor_edge=config.hidden_layers_processor_edge,
+            mlp_norm_type=config.norm_type,
+        )
+
+        # Decoder: cells back to obs through the reversed encoder graph.
+        self.decoder_edge_encoder = MLP(
+            2,
+            config.edge_dim,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+        self.decoder_gnn = GraphProcessor(
+            1,
+            config.node_dim,
+            config.edge_dim,
+            config.hidden_dim_processor_node,
+            config.hidden_dim_processor_edge,
+            config.hidden_layers_processor_node,
+            config.hidden_layers_processor_edge,
+            config.norm_type,
+            use_checkpointing=config.use_checkpointing,
+        )
+        self.node_decoder = MLP(
+            config.node_dim,
+            output_dim,
+            config.hidden_dim_decoder,
+            config.hidden_layers_decoder,
+            config.norm_type,
+            config.use_checkpointing,
+        )
+
+    def _build_encoder_graph(self, lat_lons: list, mesh: list, mesh_index: dict) -> Data:
+        """Build bipartite edges from each observation to its assigned mesh cell."""
+        assigned = assign_points_to_mesh(
+            lat_lons, mesh, self.config.coarse_res, self.config.fine_res
+        )
+        num_obs = len(lat_lons)
+        sources, targets, attrs = [], [], []
+        for node_idx, (coord, cell) in enumerate(zip(lat_lons, assigned)):
+            sources.append(node_idx)
+            targets.append(num_obs + mesh_index[cell])
+            dist = h3.great_circle_distance(coord, h3.cell_to_latlng(cell), unit="rads")
+            attrs.append([np.sin(dist), np.cos(dist)])
+        edge_index = torch.tensor([sources, targets], dtype=torch.long)
+        edge_attr = torch.tensor(attrs, dtype=torch.float)
+        return Data(edge_index=edge_index, edge_attr=edge_attr)
+
+    def _gather_embeddings(self, mesh: list, device: torch.device) -> torch.Tensor:
+        """Gather each mesh cell's embedding from the coarse or fine global table.
+
+        Cells are looked up in the row maps precomputed at init, so no global cell numbering
+        is rebuilt per call.
+        """
+        coarse_pos, coarse_rows, fine_pos, fine_rows = [], [], [], []
+        for pos, cell in enumerate(mesh):
+            if h3.get_resolution(cell) == self.config.fine_res:
+                fine_pos.append(pos)
+                fine_rows.append(self._fine_rows[cell])
+            else:
+                coarse_pos.append(pos)
+                coarse_rows.append(self._coarse_rows[cell])
+
+        embeds = torch.zeros(len(mesh), self.coarse_embeddings.shape[1], device=device)
+        if coarse_pos:
+            embeds[coarse_pos] = self.coarse_embeddings[coarse_rows]
+        if fine_pos:
+            embeds[fine_pos] = self.fine_embeddings[fine_rows]
+        return embeds
+
+    def forward(
+        self,
+        features: torch.Tensor,
+        lat_lons: list,
+        bbox: tuple,
+    ) -> torch.Tensor:
+        """Forecast the next state over a stretched mesh refined on ``bbox``.
+
+        Args:
+            features: Input features [B, N_obs, feature_dim + aux_dim].
+            lat_lons: List of (lat, lon) for the observations.
+            bbox: Region to refine as (lat_min, lat_max, lon_min, lon_max) in degrees.
+
+        Returns:
+            Predicted next state [B, N_obs, output_dim].
+        """
+        batch_size = features.shape[0]
+        num_obs = features.shape[1]
+        device = features.device
+
+        mesh = build_variable_resolution_mesh(bbox, self.config.coarse_res, self.config.fine_res)
+        mesh_index = {cell: i for i, cell in enumerate(mesh)}
+
+        enc_graph = self._build_encoder_graph(lat_lons, mesh, mesh_index).to(device)
+        lat_graph = build_variable_resolution_latent_graph(mesh).to(device)
+        mesh_embeds = self._gather_embeddings(mesh, device)
+
+        enc_edge_attr = self.edge_encoder(enc_graph.edge_attr)
+        latent_edge_attr = self.latent_edge_encoder(lat_graph.edge_attr)
+
+        # Decoder reuses the encoder edges reversed: same nodes, opposite direction.
+        dec_edge_index = enc_graph.edge_index.flip(0)
+        dec_edge_attr = self.decoder_edge_encoder(enc_graph.edge_attr)
+
+        batch_outputs = []
+        for i in range(batch_size):
+            nodes = torch.cat([features[i], mesh_embeds], dim=0)
+            nodes = self.node_encoder(nodes)
+            nodes, _ = self.encoder_gnn(nodes, enc_graph.edge_index, enc_edge_attr)
+            cell_features = nodes[num_obs:]
+
+            cell_features = self.processor(cell_features, lat_graph.edge_index, latent_edge_attr)
+
+            obs_placeholders = torch.zeros(num_obs, self.config.node_dim, device=device)
+            dec_nodes = torch.cat([obs_placeholders, cell_features], dim=0)
+            dec_nodes, _ = self.decoder_gnn(dec_nodes, dec_edge_index, dec_edge_attr)
+            obs_out = self.node_decoder(dec_nodes[:num_obs])
+            batch_outputs.append(obs_out)
+
+        out = torch.stack(batch_outputs, dim=0)
+
+        # Residual: predict the change and add it to the input.
+        out = out + features[..., : self.output_dim]
+        return out

--- a/tests/test_stretched_forecaster.py
+++ b/tests/test_stretched_forecaster.py
@@ -1,0 +1,100 @@
+"""Tests for the stretched-grid regional forecaster."""
+
+import torch
+
+from graph_weather.models.layers.stretched_mesh import (
+    build_variable_resolution_mesh,
+    mixed_resolution_embedding_indices,
+)
+from graph_weather.models.stretched_forecast import StretchedForecasterConfig
+
+BBOX = (50.0, 55.0, -2.0, 3.0)
+LAT_LONS = [(52.5, 0.5), (53.0, 1.0), (-40.0, 150.0)]
+
+
+def _small_config():
+    """A tiny config so a forward pass runs fast in tests."""
+    return StretchedForecasterConfig(
+        coarse_res=2,
+        fine_res=3,
+        feature_dim=4,
+        aux_dim=0,
+        node_dim=16,
+        edge_dim=16,
+        num_blocks=1,
+        hidden_dim_processor_node=16,
+        hidden_dim_processor_edge=16,
+        hidden_layers_processor_node=1,
+        hidden_layers_processor_edge=1,
+        hidden_dim_decoder=16,
+        hidden_layers_decoder=1,
+    )
+
+
+def test_forward_returns_one_prediction_per_observation():
+    """Forward returns [B, N_obs, output_dim] for a stretched mesh."""
+    model = _small_config().build()
+    features = torch.randn(1, len(LAT_LONS), 4)
+
+    out = model(features, LAT_LONS, BBOX)
+
+    assert out.shape == (1, len(LAT_LONS), 4)
+
+
+def test_gradient_reaches_both_embedding_tables():
+    """Both the coarse and fine tables receive gradient, so both actually train."""
+    model = _small_config().build()
+    features = torch.randn(1, len(LAT_LONS), 4)
+
+    # A plain .sum() loss is invariant under the decoder's final LayerNorm (the sum over the
+    # normalized dimension is constant), which zeroes every gradient. Use a non-invariant loss.
+    model(features, LAT_LONS, BBOX).pow(2).sum().backward()
+
+    assert model.coarse_embeddings.grad is not None
+    assert model.fine_embeddings.grad is not None
+    assert model.coarse_embeddings.grad.abs().sum() > 0
+    assert model.fine_embeddings.grad.abs().sum() > 0
+
+
+def test_runs_for_a_moved_region():
+    """The same model forecasts over a different region without rebuilding."""
+    model = _small_config().build()
+    japan_bbox = (30.0, 40.0, 135.0, 145.0)
+    japan_points = [(35.0, 139.0), (36.0, 140.0), (-40.0, 150.0)]
+    features = torch.randn(1, len(japan_points), 4)
+
+    out = model(features, japan_points, japan_bbox)
+
+    assert out.shape == (1, len(japan_points), 4)
+
+
+def test_handles_batch_dimension():
+    """A batch of several samples produces one output per sample."""
+    model = _small_config().build()
+    features = torch.randn(3, len(LAT_LONS), 4)
+
+    out = model(features, LAT_LONS, BBOX)
+
+    assert out.shape == (3, len(LAT_LONS), 4)
+
+
+def test_output_dim_defaults_to_feature_dim():
+    """With output_dim unset, the model predicts one value per input feature."""
+    config = _small_config()
+    assert config.output_dim is None
+    model = config.build()
+
+    out = model(torch.randn(1, len(LAT_LONS), 4), LAT_LONS, BBOX)
+
+    assert out.shape[-1] == config.feature_dim
+
+
+def test_cached_rows_match_embedding_index_helper():
+    """The model's precomputed row maps reproduce mixed_resolution_embedding_indices."""
+    model = _small_config().build()
+    mesh = build_variable_resolution_mesh(BBOX, 2, 3)
+    expected = mixed_resolution_embedding_indices(mesh, 2, 3)
+
+    for cell, (res, row) in zip(mesh, expected):
+        cached = model._fine_rows[cell] if res == 3 else model._coarse_rows[cell]
+        assert cached == row


### PR DESCRIPTION
# Pull Request

## Description

Adds `StretchedForecaster`, the model that runs on the variable-resolution mesh built by the earlier helpers (#226, #227, #228, #229). Instead of one mesh at a single resolution plus a boundary nudging layer, it runs encode-process-decode over a single mesh that is coarse over the globe and fine over a chosen region. The coarse/fine seam is stitched by the latent graph, so surrounding weather reaches the region without a separate boundary step.

It composes the same MLP and GNN blocks as `RegionalForecaster`. Each forward builds the mesh from a bounding box (`build_variable_resolution_mesh`), connects each observation to its assigned cell (`assign_points_to_mesh`) for the encoder, message-passes cell to cell over the latent graph (`build_variable_resolution_latent_graph`), and decodes back through the reversed encoder edges. The region is passed in as a bbox rather than inferred from the observations, so the high-res area can sit anywhere independent of where the data is.

Each cell starts from a learned embedding held in a global table per resolution, one coarse and one fine, so a cell keeps its vector as the region moves instead of relearning it. The global cell to row maps are precomputed once at init, the same way `DynamicGraphBuilder` handles its single-resolution map, so nothing is rebuilt per forward.

This is a new class rather than a change to `RegionalForecaster`, to leave that model and its tests untouched. Boundary nudging is not used in the stretched grid. No training loop here, that comes next.

Related to #3

## How Has This Been Tested?

Added `tests/test_stretched_forecaster.py` - plain pytest, tiny config so a forward runs in a few seconds, no network:
- forward returns one prediction per observation with the expected shape
- gradient reaches both the coarse and fine embedding tables (a plain sum loss is invariant under the decoder's final LayerNorm, so a squared loss is used)
- the model forecasts over a moved region without rebuilding
- a batch of several samples returns one output each
- output_dim defaults to feature_dim when unset
- the precomputed row maps match `mixed_resolution_embedding_indices`

Commands:
- `pytest tests/test_stretched_forecaster.py -q` -> 6 passed
- `ruff check graph_weather/models/stretched_forecast.py tests/test_stretched_forecaster.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
