### PR TITLE
fix: keep point assignment within the mesh at H3 boundary cells

### DIFF
--- a/graph_weather/models/layers/stretched_mesh.py
+++ b/graph_weather/models/layers/stretched_mesh.py
@@ -62,11 +62,13 @@ def assign_points_to_mesh(
 ) -> list[str]:
     """Assign each lat/lon point to the cell it belongs to in a variable-resolution mesh.
 
-    A point inside the refined region lands on its fine cell; a point outside lands on its
+    A point inside the refined region lands on its fine cell; a point outside lands on a
     coarse cell. The fine cell is tried first and used when it is present in ``mesh``,
-    otherwise the point's coarse cell is used. Because the mesh refines whole coarse cells
-    into all of their children, the fine cell is present exactly when the point sits in the
-    region, so every returned cell is a member of ``mesh`` and contains its point.
+    otherwise the point's coarse cell is used. Near coarse-cell boundaries H3 geometry and
+    hierarchy can disagree - a point's fine cell may nest under a different coarse cell than
+    the one geometrically over the point - so when that geometric coarse cell is not in the
+    mesh (it was refined away), the fine cell's parent is used instead. Either way every
+    returned cell is a member of ``mesh``.
 
     Args:
         lat_lons: Observation points as ``(lat, lon)`` in degrees.
@@ -81,7 +83,11 @@ def assign_points_to_mesh(
     assigned = []
     for lat, lon in lat_lons:
         fine = h3.latlng_to_cell(lat, lon, fine_res)
-        assigned.append(fine if fine in mesh_set else h3.latlng_to_cell(lat, lon, coarse_res))
+        if fine in mesh_set:
+            assigned.append(fine)
+        else:
+            coarse = h3.latlng_to_cell(lat, lon, coarse_res)
+            assigned.append(coarse if coarse in mesh_set else h3.cell_to_parent(fine, coarse_res))
     return assigned
 
 

--- a/tests/test_stretched_mesh.py
+++ b/tests/test_stretched_mesh.py
@@ -176,3 +176,18 @@ def test_fine_index_persists_across_different_regions():
 
     assert fine_cell in small_idx and fine_cell in large_idx
     assert small_idx[fine_cell] == large_idx[fine_cell]
+
+
+def test_assignment_stays_in_mesh_at_h3_parent_child_boundary():
+    """A point is assigned an in-mesh cell even where H3 geometry and hierarchy disagree.
+
+    At (13.33, 105.0) the point's geometric coarse cell (latlng_to_cell) is refined away by
+    this bbox, but its fine cell nests under a different, unrefined coarse cell. The coarse
+    fallback must land on a cell that is actually in the mesh.
+    """
+    bbox = (13.0, 27.0, 95.0, 110.0)
+    mesh = build_variable_resolution_mesh(bbox, coarse_res=2, fine_res=3)
+
+    assigned = assign_points_to_mesh([(13.33, 105.0)], mesh, coarse_res=2, fine_res=3)
+
+    assert assigned[0] in set(mesh)


### PR DESCRIPTION
# Pull Request

## Description

Fixes a case where `assign_points_to_mesh` could return an H3 cell that is not in the mesh, which then breaks any caller that looks the cell up by index. Near a coarse cell's boundary, H3 geometry and hierarchy disagree: a point's fine cell from `latlng_to_cell` can nest under a different coarse cell than the one geometrically over the point, so `cell_to_parent` of the fine cell is not the same as `latlng_to_cell` at the coarse resolution. When that geometric coarse cell is one the mesh refined away, the old fallback returned it, and it is no longer in the mesh.

The fix keeps the geometric coarse cell when it is in the mesh, so normal points are unchanged and still land on the cell that contains them. Only when it is not in the mesh does it fall back to the fine cell's hierarchical parent, which is always present. Either way the returned cell is a mesh member.

I hit this while feeding real IFS sub-grids through the stretched model: a random region landed on the boundary case and a point ended up on a missing cell. The existing assignment tests never picked points that straddled that boundary.

Related to #3

## How Has This Been Tested?

Added a regression test to `tests/test_stretched_mesh.py` - plain pytest, runs entirely on h3, no network:
- a point at (13.33, 105.0) with a bbox that refines its geometric coarse cell: the assigned cell must be in the mesh (this fails before the change and passes after)

Commands:
- `pytest tests/test_stretched_mesh.py -q` -> 18 passed
- `ruff check graph_weather/models/layers/stretched_mesh.py tests/test_stretched_mesh.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
