### PR TITLE
feat: add region-weighted MSE loss

### DIFF
--- a/graph_weather/models/losses.py
+++ b/graph_weather/models/losses.py
@@ -6,6 +6,38 @@ import torch.nn as nn
 import torch_harmonics as th
 
 
+def regional_weighted_mse(
+    pred: torch.Tensor,
+    target: torch.Tensor,
+    region_mask: torch.Tensor,
+    region_weight: float,
+) -> torch.Tensor:
+    """Mean squared error that upweights points inside the refined region.
+
+    On a stretched mesh most points sit in the coarse global area and only a few sit in the
+    fine region, so a plain mean is dominated by the global points and the region we refined
+    the mesh for barely drives training. This scales each in-region point's error by
+    ``region_weight`` before a weighted average, so getting the region right counts for more.
+    The average is normalized by the total weight, so ``region_weight`` sets only the balance,
+    not the loss magnitude.
+
+    Args:
+        pred: Predictions ``[B, N, C]``.
+        target: Targets ``[B, N, C]``.
+        region_mask: Boolean ``[N]``, True for points inside the refined region, e.g. points
+            assigned to a fine cell by ``assign_points_to_mesh``.
+        region_weight: Multiplier for in-region points. Points outside keep weight 1.
+
+    Returns:
+        Scalar weighted mean-squared-error loss.
+    """
+    per_point = ((pred - target) ** 2).mean(dim=-1)  # [B, N]
+    weights = torch.ones(region_mask.shape[0], dtype=per_point.dtype, device=per_point.device)
+    weights[region_mask.to(weights.device)] = region_weight
+    weighted = (per_point * weights).sum(dim=-1) / weights.sum()  # [B]
+    return weighted.mean()
+
+
 class NormalizedMSELoss(torch.nn.Module):
     """Loss function described in the paper"""
 

--- a/tests/test_regional_loss.py
+++ b/tests/test_regional_loss.py
@@ -1,0 +1,52 @@
+"""Tests for the region-weighted MSE loss."""
+
+import torch
+
+from graph_weather.models.losses import regional_weighted_mse
+
+
+def test_all_region_equals_plain_mse():
+    """When every point is in the region, any weight reduces to plain MSE."""
+    pred = torch.randn(2, 5, 3)
+    target = torch.randn(2, 5, 3)
+    mask = torch.ones(5, dtype=torch.bool)
+
+    plain = ((pred - target) ** 2).mean()
+    loss = regional_weighted_mse(pred, target, mask, region_weight=7.0)
+
+    assert torch.allclose(loss, plain)
+
+
+def test_upweighting_region_raises_loss_when_error_is_in_region():
+    """With error only on region points, a higher weight gives a higher loss."""
+    pred = torch.zeros(1, 4, 2)
+    target = torch.zeros(1, 4, 2)
+    target[0, 0] = 1.0  # error on the single in-region point only
+    mask = torch.tensor([True, False, False, False])
+
+    loss_low = regional_weighted_mse(pred, target, mask, region_weight=1.0)
+    loss_high = regional_weighted_mse(pred, target, mask, region_weight=3.0)
+
+    assert loss_high > loss_low
+
+
+def test_region_weight_one_equals_plain_mse():
+    """A weight of 1 is neutral: the loss is plain MSE for any mask."""
+    pred = torch.randn(2, 6, 3)
+    target = torch.randn(2, 6, 3)
+    mask = torch.tensor([True, False, True, False, False, True])
+
+    plain = ((pred - target) ** 2).mean()
+    loss = regional_weighted_mse(pred, target, mask, region_weight=1.0)
+
+    assert torch.allclose(loss, plain)
+
+
+def test_zero_error_gives_zero_loss():
+    """Identical prediction and target give zero loss regardless of weighting."""
+    pred = torch.randn(2, 5, 3)
+    mask = torch.tensor([True, False, True, False, True])
+
+    loss = regional_weighted_mse(pred, pred.clone(), mask, region_weight=5.0)
+
+    assert loss == 0.0


### PR DESCRIPTION
# Pull Request

## Description

Adds `regional_weighted_mse`, a loss for training the stretched-grid model. On a variable-resolution mesh most points sit in the coarse global area and only a few sit in the fine region, so a plain mean squared error is dominated by the global points and the region the mesh was refined for barely drives training. This scales each in-region point's error by a weight before a weighted average, so getting the region right counts for more.

The average is normalized by the total weight, so the weight sets only the balance between region and global error, not the overall loss magnitude. It reduces to plain MSE when the weight is 1. The caller passes a boolean mask of which points are in the region, which it can build from `assign_points_to_mesh` (a point on a fine cell is in the region), so there is one definition of "region" shared by the model and the loss.

It lives in `graph_weather/models/losses.py` next to the existing losses. Pure tensor math, no model or dataset dependency.

Related to #3

## How Has This Been Tested?

Added `tests/test_regional_loss.py` - plain pytest, small hand-made tensors, no network:
- with every point in the region, any weight reduces to plain MSE
- with error only on region points, a higher weight gives a higher loss
- a weight of 1 is neutral for any mask
- identical prediction and target give zero loss

Commands:
- `pytest tests/test_regional_loss.py -q` -> 4 passed
- `ruff check tests/test_regional_loss.py` -> clean (the added function passes ruff; losses.py has pre-existing E501/D warnings unrelated to this change)

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
