### PR TITLE
feat: add stretched dataset with global and regional observations

### DIFF
--- a/graph_weather/data/stretched_dataset.py
+++ b/graph_weather/data/stretched_dataset.py
@@ -1,0 +1,169 @@
+"""Dataset for the stretched-grid forecaster with global and regional observations.
+
+Samples one IFS grid point per coarse H3 cell (global coverage) plus a dense
+regional crop inside a movable bounding box.  Returns ``(features, lat_lons,
+target, bbox)`` shaped for ``StretchedForecaster.forward``.
+
+``_sample_box`` and ``_extract_points`` mirror the same methods in
+``RegionalDataset`` but differ in return shape (``_sample_box`` also returns the
+bbox) and scope (``_extract_points`` drops the coarsen path).  Kept separate to
+avoid modifying the merged ``regional_dataset`` module.
+"""
+
+import h3
+import numpy as np
+import torch
+import xarray as xr
+from torch.utils.data import Dataset
+
+from graph_weather.data.regional_dataset import (
+    CORE_SURFACE,
+    CORE_SURFACE_MEAN,
+    CORE_SURFACE_STD,
+    DEFAULT_STORE,
+    open_ifs_store,
+)
+from graph_weather.models.layers.stretched_mesh import build_variable_resolution_mesh
+
+
+class StretchedDataset(Dataset):
+    """Global + regional IFS samples for a variable-resolution mesh.
+
+    Args:
+        dataset: An open ``xarray.Dataset`` to sample from.  When ``None``, the
+            store at ``store_url`` is opened.
+        store_url: Source Cooperative ``<bucket>/<prefix>`` of the IFS store.
+        variables: Surface variable names to stack into the feature dimension.
+        coarse_res: H3 resolution for the global coarse mesh.
+        fine_res: H3 resolution for the refined region.
+        extent_deg: Side length of the square bounding box, in degrees.
+        max_regional_points: Cap on observation points inside the region.
+        seed: Base seed; sample ``idx`` uses ``seed + idx`` so boxes move.
+        mean: Per-variable means for standardisation.
+        std: Per-variable standard deviations for standardisation.
+    """
+
+    def __init__(
+        self,
+        dataset: xr.Dataset = None,
+        store_url: str = DEFAULT_STORE,
+        variables: list = None,
+        coarse_res: int = 2,
+        fine_res: int = 3,
+        extent_deg: float = 20.0,
+        max_regional_points: int = 2000,
+        seed: int = 0,
+        mean: dict = None,
+        std: dict = None,
+    ):
+        """Open the source grid and precompute per-cell nearest grid indices."""
+        super().__init__()
+        self.data = dataset if dataset is not None else open_ifs_store(store_url)
+        self.variables = variables if variables is not None else CORE_SURFACE
+        self.coarse_res = coarse_res
+        self.fine_res = fine_res
+        self.extent_deg = extent_deg
+        self.max_regional_points = max_regional_points
+        self.seed = seed
+        self.mean = mean if mean is not None else CORE_SURFACE_MEAN
+        self.std = std if std is not None else CORE_SURFACE_STD
+        self.lat = self.data["latitude"].values
+        self.lon = self.data["longitude"].values
+
+        # Precompute: for each coarse cell, the nearest IFS grid index.
+        self._coarse_cells = sorted(h3.uncompact_cells(h3.get_res0_cells(), coarse_res))
+        self._cell_grid_idx = {}
+        for cell in self._coarse_cells:
+            clat, clon = h3.cell_to_latlng(cell)
+            lat_i = int(np.argmin(np.abs(self.lat - clat)))
+            lon_i = int(np.argmin(np.abs(self.lon - clon)))
+            self._cell_grid_idx[cell] = (lat_i, lon_i)
+
+    def __len__(self) -> int:
+        """Number of t -> t+1 sample pairs."""
+        return int(self.data.sizes["time"]) - 1
+
+    def _sample_box(self, rng):
+        """Pick a movable bbox centre and return point grid indices and coords."""
+        half = self.extent_deg / 2.0
+        lat_c = rng.uniform(self.lat.min() + half, self.lat.max() - half)
+        lon_c = rng.uniform(self.lon.min() + half, self.lon.max() - half)
+
+        lat_idx = np.flatnonzero(np.abs(self.lat - lat_c) <= half)
+        lon_idx = np.flatnonzero(np.abs(self.lon - lon_c) <= half)
+
+        glat, glon = np.meshgrid(self.lat[lat_idx], self.lon[lon_idx], indexing="ij")
+        giy, gix = np.meshgrid(np.arange(len(lat_idx)), np.arange(len(lon_idx)), indexing="ij")
+        flat_lat, flat_lon = glat.ravel(), glon.ravel()
+        flat_iy, flat_ix = giy.ravel(), gix.ravel()
+
+        n = min(self.max_regional_points, flat_lat.size)
+        pick = rng.choice(flat_lat.size, size=n, replace=False)
+
+        bbox = (
+            float(self.lat[lat_idx[0]]),
+            float(self.lat[lat_idx[-1]]),
+            float(self.lon[lon_idx[0]]),
+            float(self.lon[lon_idx[-1]]),
+        )
+        return lat_idx, lon_idx, flat_iy[pick], flat_ix[pick], flat_lat[pick], flat_lon[pick], bbox
+
+    def _extract_points(self, t, lat_idx, lon_idx, iy, ix):
+        """Stack standardised variables at sampled points for timestep t."""
+        cols = []
+        for v in self.variables:
+            arr = self.data[v].isel(time=t, latitude=lat_idx, longitude=lon_idx).values
+            col = (arr[iy, ix] - self.mean[v]) / self.std[v]
+            cols.append(col)
+        feat = np.stack(cols, axis=-1).astype(np.float32)
+        return np.nan_to_num(feat, nan=0.0)
+
+    def _extract_scalar(self, t, lat_i, lon_i):
+        """Extract standardised variables at a single grid point for timestep t."""
+        vals = []
+        for v in self.variables:
+            raw = float(self.data[v].isel(time=t, latitude=lat_i, longitude=lon_i).values)
+            vals.append((raw - self.mean[v]) / self.std[v])
+        arr = np.array(vals, dtype=np.float32)
+        return np.nan_to_num(arr, nan=0.0)
+
+    def _global_observations(self, t, bbox):
+        """One IFS observation per coarse cell not refined away by the bbox.
+
+        Returns (features_array [N_global, F], lat_lons list of tuples).
+        """
+        mesh_set = set(
+            build_variable_resolution_mesh(bbox, self.coarse_res, self.fine_res)
+        )
+        feats, lls = [], []
+        for cell in self._coarse_cells:
+            if cell not in mesh_set:
+                # This coarse cell was refined away — skip it.
+                continue
+            lat_i, lon_i = self._cell_grid_idx[cell]
+            feats.append(self._extract_scalar(t, lat_i, lon_i))
+            clat, clon = h3.cell_to_latlng(cell)
+            lls.append((float(clat), float(clon)))
+        return np.stack(feats, axis=0), lls
+
+    def __getitem__(self, idx):
+        """Return (features, lat_lons, target, bbox) for one sample.
+
+        features/target are [N_global + N_regional, F]; lat_lons is a list of
+        (lat, lon) tuples; bbox is (lat_min, lat_max, lon_min, lon_max).
+        """
+        rng = np.random.default_rng(self.seed + idx)
+        lat_idx, lon_idx, iy, ix, plat, plon, bbox = self._sample_box(rng)
+
+        reg_feat = self._extract_points(idx, lat_idx, lon_idx, iy, ix)
+        reg_target = self._extract_points(idx + 1, lat_idx, lon_idx, iy, ix)
+        reg_lls = [(float(a), float(b)) for a, b in zip(plat, plon)]
+
+        glob_feat, glob_lls = self._global_observations(idx, bbox)
+        glob_target_feat, _ = self._global_observations(idx + 1, bbox)
+
+        features = torch.from_numpy(np.concatenate([glob_feat, reg_feat], axis=0))
+        target = torch.from_numpy(np.concatenate([glob_target_feat, reg_target], axis=0))
+        lat_lons = glob_lls + reg_lls
+
+        return features, lat_lons, target, bbox

--- a/graph_weather/data/stretched_dataset.py
+++ b/graph_weather/data/stretched_dataset.py
@@ -118,33 +118,37 @@ class StretchedDataset(Dataset):
         feat = np.stack(cols, axis=-1).astype(np.float32)
         return np.nan_to_num(feat, nan=0.0)
 
-    def _extract_scalar(self, t, lat_i, lon_i):
-        """Extract standardised variables at a single grid point for timestep t."""
-        vals = []
-        for v in self.variables:
-            raw = float(self.data[v].isel(time=t, latitude=lat_i, longitude=lon_i).values)
-            vals.append((raw - self.mean[v]) / self.std[v])
-        arr = np.array(vals, dtype=np.float32)
-        return np.nan_to_num(arr, nan=0.0)
+    def _kept_coarse(self, bbox):
+        """Coarse cells still in the mesh for this bbox: grid indices and cell centres.
 
-    def _global_observations(self, t, bbox):
-        """One IFS observation per coarse cell not refined away by the bbox.
-
-        Returns (features_array [N_global, F], lat_lons list of tuples).
+        Cells refined away by the region are dropped, so the region is covered by the
+        dense regional crop instead of a coarse observation.
         """
-        mesh_set = set(
-            build_variable_resolution_mesh(bbox, self.coarse_res, self.fine_res)
-        )
-        feats, lls = [], []
+        mesh_set = set(build_variable_resolution_mesh(bbox, self.coarse_res, self.fine_res))
+        lat_is, lon_is, centres = [], [], []
         for cell in self._coarse_cells:
             if cell not in mesh_set:
-                # This coarse cell was refined away — skip it.
                 continue
             lat_i, lon_i = self._cell_grid_idx[cell]
-            feats.append(self._extract_scalar(t, lat_i, lon_i))
+            lat_is.append(lat_i)
+            lon_is.append(lon_i)
             clat, clon = h3.cell_to_latlng(cell)
-            lls.append((float(clat), float(clon)))
-        return np.stack(feats, axis=0), lls
+            centres.append((float(clat), float(clon)))
+        return np.array(lat_is, dtype=int), np.array(lon_is, dtype=int), centres
+
+    def _extract_global(self, t, lat_is, lon_is):
+        """Stack standardised variables at scattered global grid points for timestep t.
+
+        Loads each variable's full field once and indexes all points together, rather than
+        reading one point at a time, which would be thousands of separate reads on the store.
+        """
+        cols = []
+        for v in self.variables:
+            field = self.data[v].isel(time=t).values
+            col = (field[lat_is, lon_is] - self.mean[v]) / self.std[v]
+            cols.append(col)
+        feat = np.stack(cols, axis=-1).astype(np.float32)
+        return np.nan_to_num(feat, nan=0.0)
 
     def __getitem__(self, idx):
         """Return (features, lat_lons, target, bbox) for one sample.
@@ -159,8 +163,9 @@ class StretchedDataset(Dataset):
         reg_target = self._extract_points(idx + 1, lat_idx, lon_idx, iy, ix)
         reg_lls = [(float(a), float(b)) for a, b in zip(plat, plon)]
 
-        glob_feat, glob_lls = self._global_observations(idx, bbox)
-        glob_target_feat, _ = self._global_observations(idx + 1, bbox)
+        glob_lat_is, glob_lon_is, glob_lls = self._kept_coarse(bbox)
+        glob_feat = self._extract_global(idx, glob_lat_is, glob_lon_is)
+        glob_target_feat = self._extract_global(idx + 1, glob_lat_is, glob_lon_is)
 
         features = torch.from_numpy(np.concatenate([glob_feat, reg_feat], axis=0))
         target = torch.from_numpy(np.concatenate([glob_target_feat, reg_target], axis=0))

--- a/tests/test_stretched_dataset.py
+++ b/tests/test_stretched_dataset.py
@@ -145,9 +145,7 @@ def test_global_lat_lons_are_cell_centres():
 
     coarse_cells = sorted(h3.uncompact_cells(h3.get_res0_cells(), COARSE_RES))
     mesh_set = set(mesh)
-    kept_centres = [
-        h3.cell_to_latlng(c) for c in coarse_cells if c in mesh_set
-    ]
+    kept_centres = [h3.cell_to_latlng(c) for c in coarse_cells if c in mesh_set]
     for (lat, lon), (clat, clon) in zip(global_lls, kept_centres):
         assert abs(lat - clat) < 1e-6
         assert abs(lon - clon) < 1e-6

--- a/tests/test_stretched_dataset.py
+++ b/tests/test_stretched_dataset.py
@@ -1,0 +1,154 @@
+"""Tests for StretchedDataset using a synthetic in-memory grid (no cloud)."""
+
+import h3
+import numpy as np
+import torch
+import xarray as xr
+
+from graph_weather.data.regional_dataset import CORE_SURFACE
+from graph_weather.data.stretched_dataset import StretchedDataset
+from graph_weather.models.layers.stretched_mesh import (
+    assign_points_to_mesh,
+    build_variable_resolution_mesh,
+)
+
+COARSE_RES = 2
+FINE_RES = 3
+
+
+def _synthetic_ds(n_time=4, n_lat=37, n_lon=72):
+    """Build a regular lat/lon dataset with the CORE_SURFACE variables."""
+    lat = np.linspace(-90.0, 90.0, n_lat)
+    lon = np.linspace(-180.0, 175.0, n_lon)
+    rng = np.random.default_rng(0)
+    data = {
+        v: (("time", "latitude", "longitude"), rng.standard_normal((n_time, n_lat, n_lon)))
+        for v in CORE_SURFACE
+    }
+    return xr.Dataset(data, coords={"latitude": lat, "longitude": lon, "time": np.arange(n_time)})
+
+
+def _dataset(**kwargs):
+    """StretchedDataset over the synthetic grid with test-friendly defaults."""
+    return StretchedDataset(
+        dataset=_synthetic_ds(),
+        coarse_res=COARSE_RES,
+        fine_res=FINE_RES,
+        extent_deg=40.0,
+        max_regional_points=50,
+        **kwargs,
+    )
+
+
+def test_getitem_returns_four_items():
+    """__getitem__ yields (features, lat_lons, target, bbox)."""
+    result = _dataset()[0]
+    assert len(result) == 4
+
+
+def test_features_shape_matches_lat_lons():
+    """features.shape[0] == len(lat_lons) and feature dim == len(variables)."""
+    features, lat_lons, target, _ = _dataset()[0]
+    assert features.shape[0] == len(lat_lons)
+    assert features.shape[1] == len(CORE_SURFACE)
+    assert target.shape == features.shape
+
+
+def test_lat_lons_is_list_of_tuples():
+    """lat_lons must be a plain Python list of (lat, lon) for the graph builder."""
+    _, lat_lons, _, _ = _dataset()[0]
+    assert isinstance(lat_lons, list)
+    assert isinstance(lat_lons[0], tuple) and len(lat_lons[0]) == 2
+
+
+def test_bbox_is_explicit_tuple():
+    """bbox is a 4-tuple of floats, not derived from lat_lons."""
+    _, lat_lons, _, bbox = _dataset()[0]
+    assert isinstance(bbox, tuple) and len(bbox) == 4
+    assert all(isinstance(x, float) for x in bbox)
+    # bbox must NOT span the whole globe (it's a regional box, not min/max of all points).
+    lat_min, lat_max, _, _ = bbox
+    assert lat_max - lat_min < 90.0
+
+
+def test_len_is_time_minus_one():
+    """One sample per t -> t+1 pair."""
+    assert len(_dataset()) == 3
+
+
+def test_global_points_cover_coarse_cells():
+    """Every non-refined coarse cell has at least one observation assigned to it."""
+    features, lat_lons, _, bbox = _dataset()[0]
+    mesh = build_variable_resolution_mesh(bbox, COARSE_RES, FINE_RES)
+    mesh_set = set(mesh)
+    assigned = assign_points_to_mesh(lat_lons, mesh, COARSE_RES, FINE_RES)
+
+    coarse_in_mesh = {c for c in mesh if h3.get_resolution(c) == COARSE_RES}
+    coarse_with_obs = {c for c in assigned if c in coarse_in_mesh}
+    assert coarse_with_obs == coarse_in_mesh
+
+
+def test_regional_points_inside_bbox():
+    """Regional lat_lons are within the returned bbox."""
+    _, lat_lons, _, bbox = _dataset()[0]
+    lat_min, lat_max, lon_min, lon_max = bbox
+    mesh = build_variable_resolution_mesh(bbox, COARSE_RES, FINE_RES)
+    assigned = assign_points_to_mesh(lat_lons, mesh, COARSE_RES, FINE_RES)
+
+    for (lat, lon), cell in zip(lat_lons, assigned):
+        if h3.get_resolution(cell) == FINE_RES:
+            assert lat_min <= lat <= lat_max
+            assert lon_min <= lon <= lon_max
+
+
+def test_no_nan_in_features():
+    """A fully-NaN variable produces no NaN in the output (fill after normalize)."""
+    ds_syn = _synthetic_ds()
+    ds_syn["total_cloud_cover"][:] = np.nan
+    features, _, target, _ = StretchedDataset(
+        dataset=ds_syn,
+        coarse_res=COARSE_RES,
+        fine_res=FINE_RES,
+        extent_deg=40.0,
+        max_regional_points=50,
+    )[0]
+    assert not torch.isnan(features).any()
+    assert not torch.isnan(target).any()
+
+
+def test_different_idx_moves_region():
+    """Different idx samples a different bounding box location."""
+    ds = _dataset()
+    _, _, _, bbox0 = ds[0]
+    _, _, _, bbox1 = ds[1]
+    assert bbox0 != bbox1
+
+
+def test_target_is_next_timestep():
+    """Target comes from t+1, not t, so features and target differ."""
+    features, _, target, _ = _dataset()[0]
+    assert not torch.equal(features, target)
+
+
+def test_more_points_than_regional_alone():
+    """Total points exceed max_regional_points because global points are added."""
+    features, _, _, _ = _dataset()[0]
+    assert features.shape[0] > 50
+
+
+def test_global_lat_lons_are_cell_centres():
+    """Global observations sit at coarse cell centres, not at IFS grid points."""
+    _, lat_lons, _, bbox = _dataset()[0]
+    mesh = build_variable_resolution_mesh(bbox, COARSE_RES, FINE_RES)
+    # Global points come first in the concatenation; count them from the mesh.
+    n_global = sum(1 for c in mesh if h3.get_resolution(c) == COARSE_RES)
+    global_lls = lat_lons[:n_global]
+
+    coarse_cells = sorted(h3.uncompact_cells(h3.get_res0_cells(), COARSE_RES))
+    mesh_set = set(mesh)
+    kept_centres = [
+        h3.cell_to_latlng(c) for c in coarse_cells if c in mesh_set
+    ]
+    for (lat, lon), (clat, clon) in zip(global_lls, kept_centres):
+        assert abs(lat - clat) < 1e-6
+        assert abs(lon - clon) < 1e-6

--- a/tests/test_stretched_dataset.py
+++ b/tests/test_stretched_dataset.py
@@ -62,7 +62,7 @@ def test_lat_lons_is_list_of_tuples():
 
 
 def test_bbox_is_explicit_tuple():
-    """bbox is a 4-tuple of floats, not derived from lat_lons."""
+    """The bbox is a 4-tuple of floats, not derived from lat_lons."""
     _, lat_lons, _, bbox = _dataset()[0]
     assert isinstance(bbox, tuple) and len(bbox) == 4
     assert all(isinstance(x, float) for x in bbox)
@@ -80,7 +80,6 @@ def test_global_points_cover_coarse_cells():
     """Every non-refined coarse cell has at least one observation assigned to it."""
     features, lat_lons, _, bbox = _dataset()[0]
     mesh = build_variable_resolution_mesh(bbox, COARSE_RES, FINE_RES)
-    mesh_set = set(mesh)
     assigned = assign_points_to_mesh(lat_lons, mesh, COARSE_RES, FINE_RES)
 
     coarse_in_mesh = {c for c in mesh if h3.get_resolution(c) == COARSE_RES}


### PR DESCRIPTION
# Pull Request

## Description

Adds `StretchedDataset`, which feeds `StretchedForecaster` with both global and regional observations. `RegionalDataset` only samples points inside the box, so on the stretched mesh every coarse cell got no observation and ran on its learned embedding alone, and the region weighting had nothing to weigh against. This samples one IFS grid point per coarse H3 cell for global coverage, plus a dense crop inside a movable box, so the coarse part of the mesh sees real weather and the stitched seam has something to carry into the region.

Each sample returns `(features, lat_lons, target, bbox)`. The bbox is returned explicitly rather than derived from the points: once global points are added, the min/max of `lat_lons` spans the whole globe, so the region has to be passed on its own. Global points sit at coarse cell centres and the regional points are the grid crop. Which points count as "in region" is left to the caller via `assign_points_to_mesh`, so there is one definition of region shared with the loss.

It reuses `RegionalDataset`'s store opener, variable list, and standardisation, and is a new class so the merged `RegionalDataset` (still used by the Phase-1 nudging model) is untouched. Global extraction loads each variable's field once and indexes all points together rather than reading one point at a time, so it stays fast on the real store.

Related to #3

## How Has This Been Tested?

Added `tests/test_stretched_dataset.py` - plain pytest, synthetic in-memory grid, no network:
- a sample returns the four items (features, lat_lons, target, bbox)
- features rows equal len(lat_lons), and the feature dim equals the variable count
- lat_lons is a plain list of (lat, lon) tuples
- bbox is an explicit 4-tuple, not the whole-globe min/max of the points
- every coarse cell still in the mesh has an observation assigned to it
- regional points fall inside the bbox
- a fully-missing variable produces no NaN
- a different index moves the region
- the target comes from the next timestep
- total points exceed max_regional_points because global points are added
- global observations sit at coarse cell centres

Commands:
- `pytest tests/test_stretched_dataset.py -q` -> 12 passed
- `ruff check graph_weather/data/stretched_dataset.py tests/test_stretched_dataset.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
