### PR TITLE
fix: feed encoder observation features into the stretched decoder

### DIFF
--- a/graph_weather/models/stretched_forecast.py
+++ b/graph_weather/models/stretched_forecast.py
@@ -236,12 +236,15 @@ class StretchedForecaster(nn.Module):
             nodes = torch.cat([features[i], mesh_embeds], dim=0)
             nodes = self.node_encoder(nodes)
             nodes, _ = self.encoder_gnn(nodes, enc_graph.edge_index, enc_edge_attr)
+            obs_features = nodes[:num_obs]
             cell_features = nodes[num_obs:]
 
             cell_features = self.processor(cell_features, lat_graph.edge_index, latent_edge_attr)
 
-            obs_placeholders = torch.zeros(num_obs, self.config.node_dim, device=device)
-            dec_nodes = torch.cat([obs_placeholders, cell_features], dim=0)
+            # Seed the decoder's observation nodes with their own encoded features rather than
+            # zeros, so the predicted delta can specialize per observation instead of only
+            # seeing its cell's pooled feature.
+            dec_nodes = torch.cat([obs_features, cell_features], dim=0)
             dec_nodes, _ = self.decoder_gnn(dec_nodes, dec_edge_index, dec_edge_attr)
             obs_out = self.node_decoder(dec_nodes[:num_obs])
             batch_outputs.append(obs_out)

--- a/tests/test_stretched_forecaster.py
+++ b/tests/test_stretched_forecaster.py
@@ -98,3 +98,25 @@ def test_cached_rows_match_embedding_index_helper():
     for cell, (res, row) in zip(mesh, expected):
         cached = model._fine_rows[cell] if res == 3 else model._coarse_rows[cell]
         assert cached == row
+
+
+def test_decoder_seeded_with_encoder_obs_features():
+    """The decoder's observation nodes carry the encoder's per-obs features, not zeros.
+
+    Seeding them with zeros collapses the model toward persistence, since the predicted delta
+    then only sees cell-level context. This guards that regression.
+    """
+    model = _small_config().build()
+    features = torch.randn(1, len(LAT_LONS), 4)
+
+    captured = {}
+
+    def capture(_module, inputs, _output):
+        captured["dec_input"] = inputs[0].detach()
+
+    handle = model.decoder_gnn.register_forward_hook(capture)
+    model(features, LAT_LONS, BBOX)
+    handle.remove()
+
+    obs_rows = captured["dec_input"][: len(LAT_LONS)]
+    assert obs_rows.abs().sum() > 0


### PR DESCRIPTION
# Pull Request

## Description

The stretched decoder was seeding its observation nodes with `torch.zeros`, throwing away the per-observation features the encoder had just computed. So each observation's predicted change could only be read back from its assigned cell's pooled, message-passed feature, and an observation's own values reached the output only through the fixed residual. On a 2-sample overfit the loss collapsed to the persistence baseline and would not drop further, independent of processor depth or resolution.

This seeds the decoder's observation nodes with the encoder's per-observation features (`nodes[:num_obs]`) instead of zeros, so the learnable delta can specialise per observation. No new parameters.

Evidence: on a 2-sample overfit the floor drops from 0.173 (which is the persistence baseline) to 0.136. Trained on 30 movable IFS samples and evaluated on 8 held-out regions, the fix reaches 0.171 held-out region-weighted MSE against 0.206 for the old zeros seed and 0.214 for persistence, so it beats persistence by about 20% on unseen regions where the old model managed about 4%. The same zeros-placeholder pattern is present in `RegionalForecaster` and could be a follow-up.

Related to #3

## How Has This Been Tested?

Added `test_decoder_seeded_with_encoder_obs_features` to `tests/test_stretched_forecaster.py` - a plain pytest that hooks the decoder GNN, runs a forward pass, and asserts the observation nodes it receives are non-zero (they carry the encoder output rather than the old zeros seed). It fails on the previous code.

Commands:
- `pytest tests/test_stretched_forecaster.py -q` -> 7 passed
- `ruff check graph_weather/models/stretched_forecast.py tests/test_stretched_forecaster.py` -> clean

The overfit and held-out generalisation numbers above came from local scripts against the real IFS store, with the held-out comparison run on Colab since the region-weighted training needs more than a 4GB GPU.

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
