### PR TITLE
fix: seed regional decoder observation nodes with encoder features

### DIFF
--- a/graph_weather/models/regional_forecast.py
+++ b/graph_weather/models/regional_forecast.py
@@ -274,14 +274,17 @@ class RegionalForecaster(nn.Module):
             nodes = torch.cat([features[i], regional_h3], dim=0)
             nodes = self.node_encoder(nodes)
             nodes, _ = self.encoder_gnn(nodes, enc_graph.edge_index, enc_edge_attr)
+            obs_features = nodes[:num_obs]
             h3_features = nodes[num_obs:]
 
             # Process: N rounds of H3 message passing
             h3_features = self.processor(h3_features, lat_graph.edge_index, latent_edge_attr)
 
-            # Decode: H3 -> obs through reversed bipartite GNN
-            obs_placeholders = torch.zeros(num_obs, self.config.node_dim, device=features.device)
-            dec_nodes = torch.cat([obs_placeholders, h3_features], dim=0)
+            # Decode: H3 -> obs through reversed bipartite GNN.
+            # Seed the decoder's observation nodes with their own encoded features rather
+            # than zeros, so the predicted delta can specialize per observation instead of
+            # only seeing its cell's pooled feature (mirrors the StretchedForecaster fix).
+            dec_nodes = torch.cat([obs_features, h3_features], dim=0)
             dec_nodes, _ = self.decoder_gnn(dec_nodes, dec_edge_index, dec_edge_attr)
             obs_out = self.node_decoder(dec_nodes[:num_obs])
             batch_outputs.append(obs_out)

--- a/tests/test_regional_forecast.py
+++ b/tests/test_regional_forecast.py
@@ -125,6 +125,28 @@ def test_residual_connection():
     assert torch.allclose(out, expected_residual, atol=1e-5)
 
 
+def test_decoder_seeded_with_encoder_obs_features():
+    """The decoder's observation nodes carry the encoder's per-obs features, not zeros.
+
+    Seeding them with zeros collapses the model toward persistence, since the predicted delta
+    then only sees cell-level context. This guards that regression.
+    """
+    model = _small_config().build()
+    features = torch.randn(1, 5, 16)
+
+    captured = {}
+
+    def capture(_module, inputs, _output):
+        captured["dec_input"] = inputs[0].detach()
+
+    handle = model.decoder_gnn.register_forward_hook(capture)
+    model(features, _uk_latlons())
+    handle.remove()
+
+    obs_rows = captured["dec_input"][:5]
+    assert obs_rows.abs().sum() > 0
+
+
 def _nudging_config():
     """Config with nudging enabled."""
     return RegionalForecasterConfig(


### PR DESCRIPTION
# Pull Request

## Description

`RegionalForecaster` seeds its decoder observation nodes with `torch.zeros`, discarding the per-observation features the encoder just computed - the same bug that #237 fixed in `StretchedForecaster`. Each observation's predicted change can only be read back from its assigned cell's pooled, message-passed feature, so the observation's own values reach the output only through the fixed residual. In #237 this collapsed the stretched model to the persistence baseline on a 2-sample overfit (floor 0.173 = persistence, dropping to 0.136 once fixed).

This applies the identical fix here: seed the decoder's observation nodes with the encoder's per-observation features (`nodes[:num_obs]`) instead of zeros, so the learnable delta can specialise per observation. No new parameters.

Follow-up to #237, which flagged this pattern in `RegionalForecaster`. Related to #3

## How Has This Been Tested?

Added `test_decoder_seeded_with_encoder_obs_features` to `tests/test_regional_forecast.py` - a plain pytest that hooks the decoder GNN, runs a forward pass, and asserts the observation nodes it receives are non-zero (they carry the encoder output rather than the old zeros seed). It fails on the previous code.

Commands:
- `pytest tests/test_regional_forecast.py -q` -> 14 passed
- `ruff check graph_weather/models/regional_forecast.py tests/test_regional_forecast.py` -> clean

## Checklist:

- [x] My code follows OCF's coding style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
