### PR TITLE
feat: add MOSAIC block-sparse attention and native-grid processing (#217)

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -28,6 +28,7 @@ jobs:
           pixi run -e ${{ matrix.environment }} installpyg
           pixi run -e ${{ matrix.environment }} pip install coverage==7.4.3 pytest-cov
           pixi run -e ${{ matrix.environment }} installnat
+          pixi run -e ${{ matrix.environment }} installnnja
           pixi run -e ${{ matrix.environment }} install
       - name: Setup with pytest-cov
         run: |

--- a/graph_weather/data/dataloader.py
+++ b/graph_weather/data/dataloader.py
@@ -99,7 +99,7 @@ class AnalysisDataset(Dataset):
         np.cos(day_of_year)
         solar_times = [np.array([extraterrestrial_irrad(date, lat, lon) for lat, lon in lat_lons])]
         for when in pd.date_range(
-            date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1H"
+            date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1h"
         ):
             solar_times.append(
                 np.array([extraterrestrial_irrad(when, lat, lon) for lat, lon in lat_lons])
@@ -112,7 +112,7 @@ class AnalysisDataset(Dataset):
             np.array([extraterrestrial_irrad(end_date, lat, lon) for lat, lon in lat_lons])
         ]
         for when in pd.date_range(
-            end_date - pd.Timedelta("12 hours"), end_date + pd.Timedelta("12 hours"), freq="1H"
+            end_date - pd.Timedelta("12 hours"), end_date + pd.Timedelta("12 hours"), freq="1h"
         ):
             end_solar_times.append(
                 np.array([extraterrestrial_irrad(when, lat, lon) for lat, lon in lat_lons])

--- a/graph_weather/data/weather_station_reader.py
+++ b/graph_weather/data/weather_station_reader.py
@@ -681,14 +681,14 @@ class WeatherStationReader:
         return interpolated
 
     def resample_observations(
-        self, observations: Optional[xr.Dataset], freq: str = "1H", aggregation: str = "mean"
+        self, observations: Optional[xr.Dataset], freq: str = "1h", aggregation: str = "mean"
     ) -> Optional[xr.Dataset]:
         """
         Resample observations to a different time frequency.
 
         Args:
             observations: Dataset with observations.
-            freq: Target frequency ('1H', '1D', etc.).
+            freq: Target frequency ('1h', '1D', etc.).
             aggregation: Aggregation method ('mean', 'sum', 'min', 'max').
 
         Returns:

--- a/graph_weather/models/gencast/utils/noise.py
+++ b/graph_weather/models/gencast/utils/noise.py
@@ -38,11 +38,16 @@ def generate_isotropic_noise(num_lon: int, num_lat: int, num_samples=1, isotropi
     if isotropic:
         lmax = num_lat - 1 if extend else num_lat
         mmax = lmax + 1
-        coeffs = torch.randn(num_samples, lmax, mmax, dtype=torch.complex64) / np.sqrt(
-            (num_lat**2) // 2
-        )
         isht = th.InverseRealSHT(
             nlat=num_lat, nlon=num_lon, lmax=lmax, mmax=mmax, grid="equiangular"
+        )
+        # torch-harmonics >= 0.9.0 applies triangular truncation, which clamps mmax down
+        # to lmax, so the transform can keep fewer modes than were requested. Read the
+        # retained mode counts back off the transform instead of assuming lmax/mmax are
+        # honoured verbatim. The discarded coefficients have m > l, where the associated
+        # Legendre functions vanish, so this does not change the generated noise.
+        coeffs = torch.randn(num_samples, isht.lmax, isht.mmax, dtype=torch.complex64) / np.sqrt(
+            (num_lat**2) // 2
         )
         noise = isht(coeffs) * np.sqrt(2 * np.pi)
         noise = einops.rearrange(noise, "b lat lon -> lon lat b").numpy()

--- a/graph_weather/models/mosaic/README.md
+++ b/graph_weather/models/mosaic/README.md
@@ -1,0 +1,42 @@
+# MOSAIC
+
+Unofficial implementation of components from
+[(Sparse) Attention to the Details: Preserving Spectral Fidelity in ML-based Weather Forecasting Models](https://arxiv.org/abs/2604.16429)
+(Zhdanov et al.).
+
+This subpackage provides the two parts requested in issue #217: block-sparse
+attention and processing at the native grid resolution. It is not a
+reproduction of the full forecaster.
+
+## Components
+
+| Module | Paper reference | Purpose |
+| --- | --- | --- |
+| `BlockSparseAttention` | Eq. 2, 8-11, Section 4.2 | Three-branch attention: compression, block-level top-n selection, and within-block local attention, combined by learned gating |
+| `RotaryEmbedding2D` | Section 4.3 | 2D axial rotary embedding over (lat, lon) |
+| `CrossAttentionInterpolator` | Eq. 6-7, Section 4.1 | Moves features between point sets using relative-position queries |
+| `HealpixCoarsen` / `HealpixRefine` | Eq. 12-13, Section 4.3 | Learnable pooling and unpooling of four sibling pixels |
+| `MosaicTransformerBlock` / `MosaicProcessor` | Eq. 14, Section 4.3 | Pre-norm block and a multi-scale processor whose first stage runs at native resolution |
+
+## Token ordering
+
+Block-sparse attention assumes contiguous index blocks are spatial
+neighbourhoods. On a HEALPix grid this holds in NESTED ordering, where pixel
+`p` subdivides into children `4p ... 4p+3` (Section 3.2). For irregular point
+sets, `healpix.nested_order` returns a permutation that provides the same
+property; any other locality-preserving ordering works as well, so the
+attention module never requires `healpy`.
+
+## Scope
+
+Implemented: the attention mechanism, grid transfer, hierarchical pooling and
+a processor that can be used standalone.
+
+Not implemented: the full forecaster and its 82 channel input/output, CRPS
+training, ensemble noise injection, the Triton kernel used for large
+sequences on GPU, and pretrained weights.
+
+## Provenance
+
+Written from the paper text and equations only. The reference implementation
+is published without a license, so no code from it was consulted.

--- a/graph_weather/models/mosaic/__init__.py
+++ b/graph_weather/models/mosaic/__init__.py
@@ -1,0 +1,26 @@
+"""MOSAIC block-sparse attention and native-grid processing.
+
+Modules from "(Sparse) Attention to the Details: Preserving Spectral
+Fidelity in ML-based Weather Forecasting Models" (arXiv:2604.16429).
+
+Everything here is pure PyTorch and operates on point sets of shape
+(batch, n_tokens, dim), so the components can be reused by the graph-based
+models in this repository. See README.md in this directory for scope.
+"""
+
+from .block_sparse_attention import BlockSparseAttention, RotaryEmbedding2D
+from .coarsen import HealpixCoarsen, HealpixRefine
+from .interpolate import CrossAttentionInterpolator, knn_indices
+from .layers import MosaicProcessor, MosaicTransformerBlock, SwiGLU
+
+__all__ = [
+    "BlockSparseAttention",
+    "CrossAttentionInterpolator",
+    "HealpixCoarsen",
+    "HealpixRefine",
+    "MosaicProcessor",
+    "MosaicTransformerBlock",
+    "RotaryEmbedding2D",
+    "SwiGLU",
+    "knn_indices",
+]

--- a/graph_weather/models/mosaic/block_sparse_attention.py
+++ b/graph_weather/models/mosaic/block_sparse_attention.py
@@ -1,0 +1,251 @@
+"""Block-sparse attention (BSA) from MOSAIC.
+
+Implements the three-branch block-sparse attention of
+"(Sparse) Attention to the Details: Preserving Spectral Fidelity in
+ML-based Weather Forecasting Models" (arXiv:2604.16429):
+
+- Compression: queries, keys and values are mean-pooled per block (Eq. 8)
+  and dense attention is computed between block representations (Eq. 9),
+  broadcast back to all tokens of the query block (Eq. 10).
+- Fine-grained selection: each query block (not each token) selects the
+  top-n key blocks using the compression attention scores and attends to
+  their tokens at full resolution (Eq. 11).
+- Local: full attention within each block independently. The paper uses
+  block attention instead of a sliding window because a sliding window
+  would require handling irregular boundaries on the sphere (Section 4.2).
+
+The three branch outputs are combined with learnable linear gating
+functions (Eq. 2). The paper does not specify the gate nonlinearity; this
+implementation uses a per-token sigmoid gate per branch, following the NSA
+convention the paper builds on.
+
+Tokens must already be ordered so that contiguous index blocks correspond
+to spatial neighbourhoods (e.g. HEALPix NESTED ordering, see
+graph_weather.models.mosaic.healpix). The module itself is agnostic to
+how that ordering was produced, so it works on arbitrary point sets.
+
+This is an independent implementation from the paper text only; no code
+from the (unlicensed) reference repository was used.
+"""
+
+from typing import Optional
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+
+class RotaryEmbedding2D(nn.Module):
+    """2D axial rotary position embedding on (lat, lon).
+
+    The head dimension is split in half; the first half is rotated with the
+    latitude angle and the second half with the longitude angle
+    (arXiv:2604.16429, Section 4.3).
+    """
+
+    def __init__(self, head_dim: int, theta: float = 10000.0):
+        """Initialize the rotary embedding.
+
+        Args:
+            head_dim: Per-head feature dimension. Must be divisible by 4.
+            theta: Base frequency for the rotary embedding.
+        """
+        super().__init__()
+        if head_dim % 4 != 0:
+            raise ValueError(f"head_dim must be divisible by 4, got {head_dim}")
+        self.head_dim = head_dim
+        quarter = head_dim // 4
+        inv_freq = theta ** (-torch.arange(quarter, dtype=torch.float32) / quarter)
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def _angles(self, coords: torch.Tensor) -> torch.Tensor:
+        """Compute rotation angles for each token.
+
+        Args:
+            coords: Tensor of shape (N, 2) with (lat, lon) in radians.
+
+        Returns:
+            Tensor of shape (N, head_dim // 2) of rotation angles.
+        """
+        lat = coords[:, 0:1] * self.inv_freq
+        lon = coords[:, 1:2] * self.inv_freq
+        return torch.cat([lat, lon], dim=-1)
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, coords: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Rotate queries and keys.
+
+        Args:
+            q: Queries of shape (..., N, head_dim).
+            k: Keys of shape (..., N, head_dim).
+            coords: Tensor of shape (N, 2) with (lat, lon) in radians.
+
+        Returns:
+            Rotated (q, k) with unchanged shapes.
+        """
+        angles = self._angles(coords.to(q.dtype))
+        cos = angles.cos().repeat_interleave(2, dim=-1)
+        sin = angles.sin().repeat_interleave(2, dim=-1)
+
+        def rotate(x: torch.Tensor) -> torch.Tensor:
+            x1 = x[..., 0::2]
+            x2 = x[..., 1::2]
+            rotated = torch.stack((-x2, x1), dim=-1).flatten(-2)
+            return x * cos + rotated * sin
+
+        return rotate(q), rotate(k)
+
+
+class BlockSparseAttention(nn.Module):
+    """Three-branch block-sparse attention (arXiv:2604.16429, Section 4.2).
+
+    Input tokens are grouped into contiguous blocks of block_size; the
+    caller must provide tokens in a locality-preserving order. The sequence
+    is padded internally so its length is a multiple of block_size and
+    padded positions are masked out of every softmax.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        block_size: int = 64,
+        top_n: int = 3,
+        num_kv_heads: Optional[int] = None,
+        use_rope: bool = True,
+    ):
+        """Initialize block-sparse attention.
+
+        Args:
+            dim: Model feature dimension.
+            num_heads: Number of query heads.
+            block_size: Number of tokens per block.
+            top_n: Number of key blocks each query block selects.
+            num_kv_heads: Number of key/value heads for grouped-query
+                attention. Defaults to num_heads (no grouping).
+            use_rope: Whether to apply 2D axial RoPE when coords are given.
+        """
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError(f"dim {dim} not divisible by num_heads {num_heads}")
+        num_kv_heads = num_kv_heads if num_kv_heads is not None else num_heads
+        if num_heads % num_kv_heads != 0:
+            raise ValueError(f"num_heads {num_heads} not divisible by num_kv_heads {num_kv_heads}")
+        self.dim = dim
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        self.block_size = block_size
+        self.top_n = top_n
+
+        self.q_proj = nn.Linear(dim, num_heads * self.head_dim, bias=False)
+        self.k_proj = nn.Linear(dim, num_kv_heads * self.head_dim, bias=False)
+        self.v_proj = nn.Linear(dim, num_kv_heads * self.head_dim, bias=False)
+        self.out_proj = nn.Linear(num_heads * self.head_dim, dim, bias=False)
+        # One sigmoid gate per branch (compression, selection, local), Eq. 2.
+        self.gate = nn.Linear(dim, 3)
+        self.rope = RotaryEmbedding2D(self.head_dim) if use_rope else None
+
+    def _pad(
+        self, x: torch.Tensor, coords: Optional[torch.Tensor]
+    ) -> tuple[torch.Tensor, Optional[torch.Tensor], torch.Tensor, int]:
+        """Pad tokens so the sequence length is a multiple of block_size."""
+        batch, n_tokens, _ = x.shape
+        block = self.block_size
+        pad = (block - n_tokens % block) % block
+        valid = torch.ones(batch, n_tokens + pad, dtype=torch.bool, device=x.device)
+        if pad > 0:
+            x = F.pad(x, (0, 0, 0, pad))
+            valid[:, n_tokens:] = False
+            if coords is not None:
+                coords = F.pad(coords, (0, 0, 0, pad))
+        return x, coords, valid, pad
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        coords: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Apply block-sparse attention.
+
+        Args:
+            x: Token features of shape (batch, n_tokens, dim), ordered so
+                that contiguous blocks are spatial neighbourhoods.
+            coords: Optional (n_tokens, 2) tensor of (lat, lon) in radians
+                used for 2D rotary embeddings.
+
+        Returns:
+            Tensor of shape (batch, n_tokens, dim).
+        """
+        batch, n_tokens, _ = x.shape
+        x_p, coords_p, valid, pad = self._pad(x, coords)
+        n_padded = x_p.shape[1]
+        block = self.block_size
+        m = n_padded // block
+        heads = self.num_heads
+        kv_heads = self.num_kv_heads
+        dh = self.head_dim
+        group = heads // kv_heads
+
+        q = self.q_proj(x_p).view(batch, n_padded, heads, dh).transpose(1, 2)
+        k = self.k_proj(x_p).view(batch, n_padded, kv_heads, dh).transpose(1, 2)
+        v = self.v_proj(x_p).view(batch, n_padded, kv_heads, dh).transpose(1, 2)
+        if self.rope is not None and coords_p is not None:
+            q, k = self.rope(q, k, coords_p)
+        k = k.repeat_interleave(group, dim=1)
+        v = v.repeat_interleave(group, dim=1)
+
+        q_b = q.view(batch, heads, m, block, dh)
+        k_b = k.view(batch, heads, m, block, dh)
+        v_b = v.view(batch, heads, m, block, dh)
+        valid_b = valid.view(batch, 1, m, block)
+        block_sizes = valid_b.sum(dim=-1, keepdim=True).clamp(min=1)
+
+        # Compression branch (Eq. 8-10): masked mean pooling per block.
+        mean_mask = valid_b.unsqueeze(-1).to(q_b.dtype)
+        q_bar = (q_b * mean_mask).sum(dim=3) / block_sizes
+        k_bar = (k_b * mean_mask).sum(dim=3) / block_sizes
+        v_bar = (v_b * mean_mask).sum(dim=3) / block_sizes
+        scale = dh**-0.5
+        scores = torch.einsum("bhid,bhjd->bhij", q_bar, k_bar) * scale
+        # Fully-padded key blocks are masked before the softmax and before
+        # the top-n so padding can never be selected.
+        block_valid = valid_b.any(dim=-1)
+        scores = scores.masked_fill(~block_valid.unsqueeze(2), float("-inf"))
+        attn_cg = scores.softmax(dim=-1)
+        o_cg = torch.einsum("bhij,bhjd->bhid", attn_cg, v_bar)
+        o_cg = o_cg.unsqueeze(3).expand(batch, heads, m, block, dh)
+
+        # Fine-grained selection branch (Eq. 11): the top-n key blocks are
+        # chosen per query block and shared by all tokens in that block.
+        top_n = min(self.top_n, m)
+        sel_scores = scores.mean(dim=1)
+        sel_idx = sel_scores.topk(top_n, dim=-1).indices
+        sel_idx_e = sel_idx.view(batch, 1, m, top_n, 1, 1).expand(batch, heads, m, top_n, block, dh)
+        k_sel = k_b.unsqueeze(2).expand(batch, heads, m, m, block, dh)
+        k_sel = torch.gather(k_sel, 3, sel_idx_e).flatten(3, 4)
+        v_sel = v_b.unsqueeze(2).expand(batch, heads, m, m, block, dh)
+        v_sel = torch.gather(v_sel, 3, sel_idx_e).flatten(3, 4)
+        valid_sel = valid_b.unsqueeze(2).expand(batch, 1, m, m, block)
+        idx_mask = sel_idx.view(batch, 1, m, top_n, 1).expand(batch, 1, m, top_n, block)
+        valid_sel = torch.gather(valid_sel, 3, idx_mask).flatten(3, 4)
+        fg_scores = torch.einsum("bhitd,bhisd->bhits", q_b, k_sel) * scale
+        fg_scores = fg_scores.masked_fill(~valid_sel.unsqueeze(3), float("-inf"))
+        o_fg = torch.einsum("bhits,bhisd->bhitd", fg_scores.softmax(dim=-1), v_sel)
+
+        # Local branch: attention within each block independently.
+        local_scores = torch.einsum("bhitd,bhisd->bhits", q_b, k_b) * scale
+        local_scores = local_scores.masked_fill(~valid_b.unsqueeze(3), float("-inf"))
+        o_local = torch.einsum("bhits,bhisd->bhitd", local_scores.softmax(dim=-1), v_b)
+
+        # Gated combination of the three branches (Eq. 2).
+        gates = torch.sigmoid(self.gate(x_p))
+        outs = torch.stack([o_cg, o_fg, o_local], dim=-1)
+        outs = outs.reshape(batch, heads, n_padded, dh, 3).permute(0, 2, 1, 3, 4)
+        combined = (outs * gates.view(batch, n_padded, 1, 1, 3)).sum(dim=-1)
+        combined = combined.reshape(batch, n_padded, heads * dh)
+        out = self.out_proj(combined)
+        if pad > 0:
+            out = out[:, :n_tokens]
+        return out

--- a/graph_weather/models/mosaic/block_sparse_attention.py
+++ b/graph_weather/models/mosaic/block_sparse_attention.py
@@ -41,6 +41,13 @@ class RotaryEmbedding2D(nn.Module):
     The head dimension is split in half; the first half is rotated with the
     latitude angle and the second half with the longitude angle
     (arXiv:2604.16429, Section 4.3).
+
+    The embedding treats latitude and longitude as independent linear axes,
+    so it is not continuous on the sphere: two points one degree apart score
+    differently across the +/-180 degree meridian than elsewhere, and points
+    that coincide physically at the poles but differ in longitude are not
+    identified. This is inherent to axial rotary embeddings and matters most
+    for polar and date-line regions.
     """
 
     def __init__(self, head_dim: int, theta: float = 10000.0):
@@ -220,16 +227,21 @@ class BlockSparseAttention(nn.Module):
         # Fine-grained selection branch (Eq. 11): the top-n key blocks are
         # chosen per query block and shared by all tokens in that block.
         top_n = min(self.top_n, m)
+        # Selection is shared across heads: the block scores are averaged
+        # over heads so every query head reads the same key blocks.
         sel_scores = scores.mean(dim=1)
         sel_idx = sel_scores.topk(top_n, dim=-1).indices
-        sel_idx_e = sel_idx.view(batch, 1, m, top_n, 1, 1).expand(batch, heads, m, top_n, block, dh)
-        k_sel = k_b.unsqueeze(2).expand(batch, heads, m, m, block, dh)
-        k_sel = torch.gather(k_sel, 3, sel_idx_e).flatten(3, 4)
-        v_sel = v_b.unsqueeze(2).expand(batch, heads, m, m, block, dh)
-        v_sel = torch.gather(v_sel, 3, sel_idx_e).flatten(3, 4)
-        valid_sel = valid_b.unsqueeze(2).expand(batch, 1, m, m, block)
-        idx_mask = sel_idx.view(batch, 1, m, top_n, 1).expand(batch, 1, m, top_n, block)
-        valid_sel = torch.gather(valid_sel, 3, idx_mask).flatten(3, 4)
+        # Advanced indexing rather than gather on an expanded view. The
+        # backward pass of gather allocates a buffer shaped like the (m, m)
+        # expansion, which would make training memory quadratic in n_tokens.
+        batch_idx = torch.arange(batch, device=x.device).view(batch, 1, 1, 1)
+        head_idx = torch.arange(heads, device=x.device).view(1, heads, 1, 1)
+        block_idx = sel_idx.view(batch, 1, m, top_n)
+        k_sel = k_b[batch_idx, head_idx, block_idx].flatten(3, 4)
+        v_sel = v_b[batch_idx, head_idx, block_idx].flatten(3, 4)
+        valid_flat = valid_b.view(batch, m, block)
+        valid_sel = valid_flat[batch_idx.view(batch, 1, 1), sel_idx]
+        valid_sel = valid_sel.reshape(batch, 1, m, top_n * block)
         fg_scores = torch.einsum("bhitd,bhisd->bhits", q_b, k_sel) * scale
         fg_scores = fg_scores.masked_fill(~valid_sel.unsqueeze(3), float("-inf"))
         o_fg = torch.einsum("bhits,bhisd->bhitd", fg_scores.softmax(dim=-1), v_sel)

--- a/graph_weather/models/mosaic/block_sparse_attention.py
+++ b/graph_weather/models/mosaic/block_sparse_attention.py
@@ -111,6 +111,13 @@ class BlockSparseAttention(nn.Module):
     caller must provide tokens in a locality-preserving order. The sequence
     is padded internally so its length is a multiple of block_size and
     padded positions are masked out of every softmax.
+
+    Cost follows the paper: with n tokens, block size b and top_n = k, the
+    selection and local branches are linear in n, while the compression
+    branch attends between all (n / b) block representations and so is
+    quadratic in the block count. Choose block_size to grow with the token
+    count to keep that term small; at n = 1e6 and b = 64 the block scores
+    alone need about 1GB per head in float32.
     """
 
     def __init__(

--- a/graph_weather/models/mosaic/coarsen.py
+++ b/graph_weather/models/mosaic/coarsen.py
@@ -52,9 +52,17 @@ class HealpixCoarsen(nn.Module):
         n_parent = n_tokens // self.factor
         grouped = x.reshape(batch, n_parent, self.factor * self.in_dim)
         out = self.feature_proj(grouped)
-        if rel_pos is not None:
-            if self.position_proj is None:
-                raise ValueError("rel_pos given but the layer was built with use_positions=False")
+        if self.position_proj is None:
+            if rel_pos is not None:
+                raise ValueError(
+                    "rel_pos was given but the layer was built with use_positions=False"
+                )
+        else:
+            if rel_pos is None:
+                raise ValueError(
+                    "rel_pos is required when use_positions=True; pass positions or "
+                    "build the layer with use_positions=False"
+                )
             pos = rel_pos.reshape(n_parent, self.factor * 3)
             out = out + self.position_proj(pos).unsqueeze(0)
         return self.norm(out)
@@ -95,8 +103,16 @@ class HealpixRefine(nn.Module):
         """
         batch, n_parent, _ = x.shape
         out = self.feature_proj(x).reshape(batch, n_parent * self.factor, self.out_dim)
-        if rel_pos is not None:
-            if self.position_proj is None:
-                raise ValueError("rel_pos given but the layer was built with use_positions=False")
+        if self.position_proj is None:
+            if rel_pos is not None:
+                raise ValueError(
+                    "rel_pos was given but the layer was built with use_positions=False"
+                )
+        else:
+            if rel_pos is None:
+                raise ValueError(
+                    "rel_pos is required when use_positions=True; pass positions or "
+                    "build the layer with use_positions=False"
+                )
             out = out + self.position_proj(rel_pos).unsqueeze(0)
         return self.norm(out)

--- a/graph_weather/models/mosaic/coarsen.py
+++ b/graph_weather/models/mosaic/coarsen.py
@@ -1,0 +1,102 @@
+"""Learnable HEALPix pooling and unpooling (MOSAIC Eq. 12-13).
+
+In NESTED ordering the four children of a HEALPix pixel are consecutive, so
+coarsening is a reshape followed by a learnable projection of the stacked
+child features and their relative positions (arXiv:2604.16429, Section 4.3).
+Refinement mirrors it. No graph library is needed.
+"""
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+class HealpixCoarsen(nn.Module):
+    """Pool four sibling pixels into their parent (Eq. 12)."""
+
+    def __init__(self, in_dim: int, out_dim: int, factor: int = 4, use_positions: bool = True):
+        """Initialize the pooling layer.
+
+        Args:
+            in_dim: Feature dimension of the fine level.
+            out_dim: Feature dimension of the coarse level.
+            factor: Number of children per parent; 4 for HEALPix.
+            use_positions: Whether to include the relative-position term of
+                Eq. 12. Set to False when no positions will be supplied so
+                the layer holds no unused parameters.
+        """
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.factor = factor
+        self.feature_proj = nn.Linear(factor * in_dim, out_dim, bias=False)
+        self.position_proj = nn.Linear(factor * 3, out_dim, bias=False) if use_positions else None
+        self.norm = nn.RMSNorm(out_dim)
+
+    def forward(self, x: torch.Tensor, rel_pos: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Coarsen features by a factor of four.
+
+        Args:
+            x: Tensor of shape (batch, n_tokens, in_dim); n_tokens must be
+                divisible by the pooling factor.
+            rel_pos: Optional (n_tokens, 3) child positions relative to the
+                parent pixel centre.
+
+        Returns:
+            Tensor of shape (batch, n_tokens // factor, out_dim).
+        """
+        batch, n_tokens, _ = x.shape
+        if n_tokens % self.factor != 0:
+            raise ValueError(f"n_tokens {n_tokens} not divisible by factor {self.factor}")
+        n_parent = n_tokens // self.factor
+        grouped = x.reshape(batch, n_parent, self.factor * self.in_dim)
+        out = self.feature_proj(grouped)
+        if rel_pos is not None:
+            if self.position_proj is None:
+                raise ValueError("rel_pos given but the layer was built with use_positions=False")
+            pos = rel_pos.reshape(n_parent, self.factor * 3)
+            out = out + self.position_proj(pos).unsqueeze(0)
+        return self.norm(out)
+
+
+class HealpixRefine(nn.Module):
+    """Expand a parent pixel back into its four children (Eq. 13)."""
+
+    def __init__(self, in_dim: int, out_dim: int, factor: int = 4, use_positions: bool = True):
+        """Initialize the unpooling layer.
+
+        Args:
+            in_dim: Feature dimension of the coarse level.
+            out_dim: Feature dimension of the fine level.
+            factor: Number of children per parent; 4 for HEALPix.
+            use_positions: Whether to include the relative-position term of
+                Eq. 13. Set to False when no positions will be supplied so
+                the layer holds no unused parameters.
+        """
+        super().__init__()
+        self.in_dim = in_dim
+        self.out_dim = out_dim
+        self.factor = factor
+        self.feature_proj = nn.Linear(in_dim, factor * out_dim, bias=False)
+        self.position_proj = nn.Linear(3, out_dim, bias=False) if use_positions else None
+        self.norm = nn.RMSNorm(out_dim)
+
+    def forward(self, x: torch.Tensor, rel_pos: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Refine features by a factor of four.
+
+        Args:
+            x: Tensor of shape (batch, n_parent, in_dim).
+            rel_pos: Optional (n_parent * factor, 3) child positions
+                relative to the parent pixel centre.
+
+        Returns:
+            Tensor of shape (batch, n_parent * factor, out_dim).
+        """
+        batch, n_parent, _ = x.shape
+        out = self.feature_proj(x).reshape(batch, n_parent * self.factor, self.out_dim)
+        if rel_pos is not None:
+            if self.position_proj is None:
+                raise ValueError("rel_pos given but the layer was built with use_positions=False")
+            out = out + self.position_proj(rel_pos).unsqueeze(0)
+        return self.norm(out)

--- a/graph_weather/models/mosaic/healpix.py
+++ b/graph_weather/models/mosaic/healpix.py
@@ -1,0 +1,83 @@
+"""HEALPix helpers for MOSAIC block-sparse attention.
+
+With NESTED indexing a HEALPix pixel p subdivides into the four children
+4p, 4p+1, 4p+2 and 4p+3, so contiguous index ranges correspond to spatial
+neighbourhoods on the sphere (arXiv:2604.16429, Section 3.2). That is the
+property block-sparse attention relies on: a block of consecutive tokens
+is a compact region rather than an arbitrary set of points.
+
+healpy is an optional dependency. It is listed in the pixi environment but
+not in the package requirements, so it is imported lazily and only the
+functions in this module need it. Block-sparse attention itself never
+requires healpy: any locality-preserving ordering can be supplied by the
+caller.
+"""
+
+from typing import Optional
+
+import torch
+
+try:  # pragma: no cover - exercised only when healpy is absent
+    import healpy
+except ImportError:
+    healpy = None
+
+
+def _require_healpy() -> None:
+    """Raise a helpful error when healpy is needed but not installed."""
+    if healpy is None:
+        raise ImportError(
+            "healpy is required for HEALPix ordering. Install it with "
+            "`pip install healpy`, or pass your own locality-preserving "
+            "token order to BlockSparseAttention."
+        )
+
+
+def healpix_grid(nside: int, dtype: torch.dtype = torch.float32) -> torch.Tensor:
+    """Return the (lat, lon) coordinates of a HEALPix grid in NESTED order.
+
+    Args:
+        nside: HEALPix resolution parameter; the grid has 12 * nside ** 2
+            pixels.
+        dtype: Floating point dtype of the returned tensor.
+
+    Returns:
+        Tensor of shape (12 * nside ** 2, 2) holding (lat, lon) in radians.
+    """
+    _require_healpy()
+    n_pixels = 12 * nside * nside
+    lon_deg, lat_deg = healpy.pix2ang(nside, torch.arange(n_pixels).numpy(), nest=True, lonlat=True)
+    lat = torch.deg2rad(torch.as_tensor(lat_deg, dtype=dtype))
+    lon = torch.deg2rad(torch.as_tensor(lon_deg, dtype=dtype))
+    return torch.stack([lat, lon], dim=-1)
+
+
+def nested_order(coords: torch.Tensor, nside: Optional[int] = None) -> torch.Tensor:
+    """Order arbitrary points so contiguous blocks are spatial neighbours.
+
+    Points are binned into HEALPix pixels in NESTED ordering and sorted by
+    pixel index, which places nearby points next to each other regardless of
+    the original ordering. This lets block-sparse attention run on point
+    sets such as station networks, not only on regular grids.
+
+    Args:
+        coords: Tensor of shape (n_points, 2) with (lat, lon) in radians.
+        nside: HEALPix resolution used for binning. Defaults to the smallest
+            power of two that gives at least as many pixels as points.
+
+    Returns:
+        Long tensor of shape (n_points,) with the permutation that sorts the
+        points into NESTED order.
+    """
+    _require_healpy()
+    if coords.ndim != 2 or coords.shape[-1] != 2:
+        raise ValueError(f"coords must have shape (n_points, 2), got {tuple(coords.shape)}")
+    n_points = coords.shape[0]
+    if nside is None:
+        nside = 1
+        while 12 * nside * nside < n_points:
+            nside *= 2
+    lat_deg = torch.rad2deg(coords[:, 0]).double().numpy()
+    lon_deg = torch.rad2deg(coords[:, 1]).double().numpy()
+    pixels = healpy.ang2pix(nside, lon_deg, lat_deg, nest=True, lonlat=True)
+    return torch.argsort(torch.as_tensor(pixels, dtype=torch.long), stable=True)

--- a/graph_weather/models/mosaic/healpix.py
+++ b/graph_weather/models/mosaic/healpix.py
@@ -23,6 +23,12 @@ except ImportError:
     healpy = None
 
 
+def _check_nside(nside: int) -> None:
+    """Validate that nside is a positive power of two, as NESTED requires."""
+    if nside < 1 or (nside & (nside - 1)) != 0:
+        raise ValueError(f"nside must be a positive power of two, got {nside}")
+
+
 def _require_healpy() -> None:
     """Raise a helpful error when healpy is needed but not installed."""
     if healpy is None:
@@ -45,6 +51,7 @@ def healpix_grid(nside: int, dtype: torch.dtype = torch.float32) -> torch.Tensor
         Tensor of shape (12 * nside ** 2, 2) holding (lat, lon) in radians.
     """
     _require_healpy()
+    _check_nside(nside)
     n_pixels = 12 * nside * nside
     lon_deg, lat_deg = healpy.pix2ang(nside, torch.arange(n_pixels).numpy(), nest=True, lonlat=True)
     lat = torch.deg2rad(torch.as_tensor(lat_deg, dtype=dtype))
@@ -77,6 +84,8 @@ def nested_order(coords: torch.Tensor, nside: Optional[int] = None) -> torch.Ten
         nside = 1
         while 12 * nside * nside < n_points:
             nside *= 2
+    else:
+        _check_nside(nside)
     lat_deg = torch.rad2deg(coords[:, 0]).double().numpy()
     lon_deg = torch.rad2deg(coords[:, 1]).double().numpy()
     pixels = healpy.ang2pix(nside, lon_deg, lat_deg, nest=True, lonlat=True)

--- a/graph_weather/models/mosaic/interpolate.py
+++ b/graph_weather/models/mosaic/interpolate.py
@@ -49,16 +49,19 @@ def knn_indices(
 class CrossAttentionInterpolator(nn.Module):
     """Interpolate features from one point set to another (Eq. 6-7)."""
 
-    def __init__(self, dim: int, num_neighbors: int = 4):
+    def __init__(self, dim: int, num_neighbors: int = 4, eps: float = 1e-12):
         """Initialize the interpolator.
 
         Args:
             dim: Feature dimension of source and target features.
             num_neighbors: Number of source neighbours attended per target.
+            eps: Squared length below which a target and a source point are
+                treated as coincident and the relative direction is zero.
         """
         super().__init__()
         self.dim = dim
         self.num_neighbors = num_neighbors
+        self.eps = eps
         self.q_proj = nn.Linear(3, dim, bias=False)
         self.k_proj = nn.Linear(dim, dim, bias=False)
         self.v_proj = nn.Linear(dim, dim, bias=False)
@@ -95,12 +98,17 @@ class CrossAttentionInterpolator(nn.Module):
         rel = source_coords[neighbor_idx] - target_coords.unsqueeze(1)
         # A target that coincides with a source point gives a zero vector,
         # where the direction is undefined and the derivative of the
-        # normalisation diverges. Coordinates lie on the unit sphere, so
-        # softening the length with 1e-6 under the square root bounds the
-        # derivative without affecting well-separated points. Clamping the
-        # norm after the fact would not: the derivative would still pass
-        # through norm() at zero.
-        rel = rel * (rel.pow(2).sum(-1, keepdim=True) + 1e-6).rsqrt()
+        # normalisation diverges. Points closer than sqrt(eps) are treated
+        # as coincident and get a zero direction; everything else is
+        # normalised exactly, so short-range neighbours on a fine grid are
+        # not distorted. Substituting the length before the reciprocal
+        # square root, rather than clamping afterwards, is what keeps the
+        # derivative of the degenerate branch finite.
+        length_sq = rel.pow(2).sum(-1, keepdim=True)
+        degenerate = length_sq <= self.eps
+        safe_length_sq = torch.where(degenerate, torch.ones_like(length_sq), length_sq)
+        rel = rel * safe_length_sq.rsqrt()
+        rel = torch.where(degenerate, torch.zeros_like(rel), rel)
         queries = self.q_proj(rel)
 
         feats = self.norm(source_feats)

--- a/graph_weather/models/mosaic/interpolate.py
+++ b/graph_weather/models/mosaic/interpolate.py
@@ -1,0 +1,95 @@
+"""Cross-attention interpolation between point sets (MOSAIC Eq. 6-7).
+
+MOSAIC moves features between the native input grid and the HEALPix grid
+with a cross-attention interpolation layer: queries are formed from the
+L2-normalised relative position between a target point and its nearest
+source points, while keys and values come from the source features
+(arXiv:2604.16429, Section 4.1). Because it is defined purely in terms of
+neighbour positions, the same layer works for arbitrary point sets in
+either direction.
+"""
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+
+def knn_indices(source_coords: torch.Tensor, target_coords: torch.Tensor, k: int) -> torch.Tensor:
+    """Find the k nearest source points for each target point.
+
+    Args:
+        source_coords: Tensor of shape (n_source, 3) of unit-sphere
+            Cartesian coordinates.
+        target_coords: Tensor of shape (n_target, 3) of unit-sphere
+            Cartesian coordinates.
+        k: Number of neighbours per target point.
+
+    Returns:
+        Long tensor of shape (n_target, k) of source indices.
+    """
+    k = min(k, source_coords.shape[0])
+    distances = torch.cdist(target_coords, source_coords)
+    return distances.topk(k, dim=-1, largest=False).indices
+
+
+class CrossAttentionInterpolator(nn.Module):
+    """Interpolate features from one point set to another (Eq. 6-7)."""
+
+    def __init__(self, dim: int, num_neighbors: int = 4):
+        """Initialize the interpolator.
+
+        Args:
+            dim: Feature dimension of source and target features.
+            num_neighbors: Number of source neighbours attended per target.
+        """
+        super().__init__()
+        self.dim = dim
+        self.num_neighbors = num_neighbors
+        self.q_proj = nn.Linear(3, dim, bias=False)
+        self.k_proj = nn.Linear(dim, dim, bias=False)
+        self.v_proj = nn.Linear(dim, dim, bias=False)
+        self.out_proj = nn.Linear(dim, dim, bias=False)
+        self.norm = nn.RMSNorm(dim)
+
+    def forward(
+        self,
+        source_feats: torch.Tensor,
+        source_coords: torch.Tensor,
+        target_coords: torch.Tensor,
+        neighbor_idx: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Interpolate source features onto the target points.
+
+        Args:
+            source_feats: Tensor of shape (batch, n_source, dim).
+            source_coords: Tensor of shape (n_source, 3) of unit-sphere
+                Cartesian coordinates.
+            target_coords: Tensor of shape (n_target, 3) of unit-sphere
+                Cartesian coordinates.
+            neighbor_idx: Optional precomputed (n_target, k) neighbour
+                indices; computed on the fly when omitted.
+
+        Returns:
+            Tensor of shape (batch, n_target, dim).
+        """
+        if neighbor_idx is None:
+            neighbor_idx = knn_indices(source_coords, target_coords, self.num_neighbors)
+        batch = source_feats.shape[0]
+        n_target, k = neighbor_idx.shape
+
+        # Relative positions target -> neighbouring source points (Eq. 6).
+        rel = source_coords[neighbor_idx] - target_coords.unsqueeze(1)
+        rel = rel / rel.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+        queries = self.q_proj(rel)
+
+        feats = self.norm(source_feats)
+        gathered = feats[:, neighbor_idx.reshape(-1)].view(batch, n_target, k, -1)
+        keys = self.k_proj(gathered)
+        values = self.v_proj(gathered)
+
+        scale = self.dim**-0.5
+        scores = (queries.unsqueeze(0) * keys).sum(dim=-1) * scale
+        weights = scores.softmax(dim=-1)
+        out = (weights.unsqueeze(-1) * values).sum(dim=2)
+        return self.out_proj(out)

--- a/graph_weather/models/mosaic/interpolate.py
+++ b/graph_weather/models/mosaic/interpolate.py
@@ -15,8 +15,16 @@ import torch
 from torch import nn
 
 
-def knn_indices(source_coords: torch.Tensor, target_coords: torch.Tensor, k: int) -> torch.Tensor:
+def knn_indices(
+    source_coords: torch.Tensor,
+    target_coords: torch.Tensor,
+    k: int,
+    chunk_size: int = 4096,
+) -> torch.Tensor:
     """Find the k nearest source points for each target point.
+
+    The pairwise distances are computed in chunks over the target points so
+    the full (n_target, n_source) matrix is never held at once.
 
     Args:
         source_coords: Tensor of shape (n_source, 3) of unit-sphere
@@ -24,13 +32,18 @@ def knn_indices(source_coords: torch.Tensor, target_coords: torch.Tensor, k: int
         target_coords: Tensor of shape (n_target, 3) of unit-sphere
             Cartesian coordinates.
         k: Number of neighbours per target point.
+        chunk_size: Number of target points handled per chunk.
 
     Returns:
         Long tensor of shape (n_target, k) of source indices.
     """
     k = min(k, source_coords.shape[0])
-    distances = torch.cdist(target_coords, source_coords)
-    return distances.topk(k, dim=-1, largest=False).indices
+    chunks = []
+    for start in range(0, target_coords.shape[0], chunk_size):
+        block = target_coords[start : start + chunk_size]
+        distances = torch.cdist(block, source_coords)
+        chunks.append(distances.topk(k, dim=-1, largest=False).indices)
+    return torch.cat(chunks, dim=0)
 
 
 class CrossAttentionInterpolator(nn.Module):

--- a/graph_weather/models/mosaic/interpolate.py
+++ b/graph_weather/models/mosaic/interpolate.py
@@ -93,7 +93,14 @@ class CrossAttentionInterpolator(nn.Module):
 
         # Relative positions target -> neighbouring source points (Eq. 6).
         rel = source_coords[neighbor_idx] - target_coords.unsqueeze(1)
-        rel = rel / rel.norm(dim=-1, keepdim=True).clamp(min=1e-6)
+        # A target that coincides with a source point gives a zero vector,
+        # where the direction is undefined and the derivative of the
+        # normalisation diverges. Coordinates lie on the unit sphere, so
+        # softening the length with 1e-6 under the square root bounds the
+        # derivative without affecting well-separated points. Clamping the
+        # norm after the fact would not: the derivative would still pass
+        # through norm() at zero.
+        rel = rel * (rel.pow(2).sum(-1, keepdim=True) + 1e-6).rsqrt()
         queries = self.q_proj(rel)
 
         feats = self.norm(source_feats)

--- a/graph_weather/models/mosaic/layers.py
+++ b/graph_weather/models/mosaic/layers.py
@@ -166,6 +166,12 @@ class MosaicProcessor(nn.Module):
         Returns:
             Tensor of shape (batch, n_tokens, dim).
         """
+        required = 4 ** (len(self.depths) - 1)
+        if x.shape[1] % required != 0:
+            raise ValueError(
+                f"n_tokens {x.shape[1]} must be divisible by {required} for "
+                f"{len(self.depths)} stages"
+            )
         skips = []
         level_coords = coords
         for index, blocks in enumerate(self.stages):

--- a/graph_weather/models/mosaic/layers.py
+++ b/graph_weather/models/mosaic/layers.py
@@ -1,0 +1,180 @@
+"""MOSAIC transformer block and native-grid processor.
+
+The processor keeps the defining property of MOSAIC: spatial interactions
+are computed at the native resolution before any coarsening occurs
+(arXiv:2604.16429, Section 4.3). Entering the hierarchy at a coarser level
+was shown to introduce high-frequency aliasing rather than merely smoothing
+the forecast.
+"""
+
+from typing import Optional
+
+import torch
+from torch import nn
+
+from .block_sparse_attention import BlockSparseAttention
+from .coarsen import HealpixCoarsen, HealpixRefine
+
+
+class SwiGLU(nn.Module):
+    """SwiGLU feed-forward network (Eq. 14)."""
+
+    def __init__(self, dim: int, hidden_ratio: float = 4.0):
+        """Initialize the feed-forward network.
+
+        Args:
+            dim: Model feature dimension.
+            hidden_ratio: Hidden dimension as a multiple of dim.
+        """
+        super().__init__()
+        hidden = int(dim * hidden_ratio)
+        self.gate_proj = nn.Linear(dim, hidden, bias=False)
+        self.value_proj = nn.Linear(dim, hidden, bias=False)
+        self.out_proj = nn.Linear(hidden, dim, bias=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Apply the feed-forward network.
+
+        Args:
+            x: Tensor of shape (batch, n_tokens, dim).
+
+        Returns:
+            Tensor of shape (batch, n_tokens, dim).
+        """
+        return self.out_proj(torch.nn.functional.silu(self.gate_proj(x)) * self.value_proj(x))
+
+
+class MosaicTransformerBlock(nn.Module):
+    """Pre-norm transformer block with block-sparse attention (Eq. 14)."""
+
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        block_size: int = 64,
+        top_n: int = 3,
+        num_kv_heads: Optional[int] = None,
+        hidden_ratio: float = 4.0,
+    ):
+        """Initialize the transformer block.
+
+        Args:
+            dim: Model feature dimension.
+            num_heads: Number of query heads.
+            block_size: Number of tokens per attention block.
+            top_n: Number of key blocks selected per query block.
+            num_kv_heads: Number of key/value heads for grouped-query
+                attention.
+            hidden_ratio: Feed-forward hidden dimension multiplier.
+        """
+        super().__init__()
+        self.attention_norm = nn.RMSNorm(dim)
+        self.attention = BlockSparseAttention(
+            dim,
+            num_heads,
+            block_size=block_size,
+            top_n=top_n,
+            num_kv_heads=num_kv_heads,
+        )
+        self.ffn_norm = nn.RMSNorm(dim)
+        self.ffn = SwiGLU(dim, hidden_ratio=hidden_ratio)
+
+    def forward(self, x: torch.Tensor, coords: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Apply attention and feed-forward with residual connections.
+
+        Args:
+            x: Tensor of shape (batch, n_tokens, dim).
+            coords: Optional (n_tokens, 2) tensor of (lat, lon) in radians.
+
+        Returns:
+            Tensor of shape (batch, n_tokens, dim).
+        """
+        x = x + self.attention(self.attention_norm(x), coords)
+        return x + self.ffn(self.ffn_norm(x))
+
+
+class MosaicProcessor(nn.Module):
+    """Multi-scale processor operating first at the native resolution.
+
+    The first stage runs block-sparse attention on the input tokens before
+    any pooling, which is what preserves fine-scale spectral content
+    (Section 4.3). Later stages operate on progressively coarser levels and
+    their outputs are added back through skip connections.
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        depths: tuple[int, ...] = (2, 2),
+        num_heads: int = 4,
+        block_size: int = 16,
+        top_n: int = 2,
+        num_kv_heads: Optional[int] = None,
+    ):
+        """Initialize the processor.
+
+        Args:
+            dim: Model feature dimension, kept constant across stages.
+            depths: Number of transformer blocks at each resolution level.
+            num_heads: Number of query heads.
+            block_size: Number of tokens per attention block.
+            top_n: Number of key blocks selected per query block.
+            num_kv_heads: Number of key/value heads for grouped-query
+                attention.
+        """
+        super().__init__()
+        if len(depths) < 1:
+            raise ValueError("depths must contain at least one stage")
+        self.depths = depths
+        self.stages = nn.ModuleList()
+        for depth in depths:
+            self.stages.append(
+                nn.ModuleList(
+                    [
+                        MosaicTransformerBlock(
+                            dim,
+                            num_heads,
+                            block_size=block_size,
+                            top_n=top_n,
+                            num_kv_heads=num_kv_heads,
+                        )
+                        for _ in range(depth)
+                    ]
+                )
+            )
+        n_transitions = len(depths) - 1
+        # The processor tracks token features only, so the pooling layers
+        # are built without their relative-position term (Eq. 12-13). Supply
+        # positions by calling HealpixCoarsen/HealpixRefine directly.
+        self.coarsen = nn.ModuleList(
+            [HealpixCoarsen(dim, dim, use_positions=False) for _ in range(n_transitions)]
+        )
+        self.refine = nn.ModuleList(
+            [HealpixRefine(dim, dim, use_positions=False) for _ in range(n_transitions)]
+        )
+
+    def forward(self, x: torch.Tensor, coords: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """Run the multi-scale processor.
+
+        Args:
+            x: Tensor of shape (batch, n_tokens, dim) in a locality
+                preserving order. n_tokens must be divisible by
+                4 ** (len(depths) - 1).
+            coords: Optional (n_tokens, 2) tensor of (lat, lon) in radians
+                used by the native-resolution stage.
+
+        Returns:
+            Tensor of shape (batch, n_tokens, dim).
+        """
+        skips = []
+        level_coords = coords
+        for index, blocks in enumerate(self.stages):
+            for block in blocks:
+                x = block(x, level_coords)
+            if index < len(self.coarsen):
+                skips.append(x)
+                x = self.coarsen[index](x)
+                level_coords = None
+        for index in reversed(range(len(self.refine))):
+            x = self.refine[index](x) + skips[index]
+        return x

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ platforms = ["linux-64", "osx-arm64"]
 
 [tool.pixi.dependencies]
 python = "3.12.*"
-pytorch = "2.10.*"
+pytorch = "2.10.0"
 pip = "*"
 pytest = "*"
 pre-commit = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ platforms = ["linux-64", "osx-arm64"]
 
 [tool.pixi.dependencies]
 python = "3.12.*"
+pytorch = "2.10.*"
 pip = "*"
 pytest = "*"
 pre-commit = "*"
@@ -95,8 +96,8 @@ install = "pip install --editable ."
 installnnja = "pip install git+https://github.com/brightbandtech/nnja-ai.git"
 installnat = "pip install natten"
 installnatcuda = "pip install natten==0.20.1+torch270cu128 -f https://whl.natten.org"
-installpyg = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.7.0+cpu.html"
-installpygcuda = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.7.0+cuda128.html"
+installpyg = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.10.0+cpu.html"
+installpygcuda = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.10.0+cu128.html"
 test = "pytest"
 format = "ruff format"
 

--- a/tests/test_anemoi.py
+++ b/tests/test_anemoi.py
@@ -7,13 +7,15 @@ from graph_weather.data import AnemoiDataset
 
 
 def fake_open_dataset(config):
-    # Create a small, synthetic xarray.Dataset for testing
+    # Create a small, synthetic xarray.Dataset for testing. The generator is seeded so the
+    # tests below do not depend on the global numpy random state.
+    rng = np.random.default_rng(0)
     data = xr.Dataset(
         {
-            "temperature": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
-            "geopotential": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
-            "u_component_of_wind": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
-            "v_component_of_wind": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
+            "temperature": (("time", "lat", "lon"), rng.random((3, 2, 2))),
+            "geopotential": (("time", "lat", "lon"), rng.random((3, 2, 2))),
+            "u_component_of_wind": (("time", "lat", "lon"), rng.random((3, 2, 2))),
+            "v_component_of_wind": (("time", "lat", "lon"), rng.random((3, 2, 2))),
         },
         coords={
             "time": pd.date_range("2020-01-01", periods=3),
@@ -74,7 +76,11 @@ def test_normalization():
             features=["temperature"],
             max_samples=3,
             means={"temperature": 0.5},
-            stds={"temperature": 0.2},
+            # The synthetic data is uniform on [0, 1), so its standard deviation is
+            # 1/sqrt(12). Declaring 0.2 instead put the expected normalised spread at 1.44,
+            # right against the 1.5 bound asserted below, and the twelve-value sample went
+            # over it often enough to make this test flaky.
+            stds={"temperature": float(1 / np.sqrt(12))},
         )
         samples = []
         for i in range(min(3, len(dataset))):

--- a/tests/test_gencast.py
+++ b/tests/test_gencast.py
@@ -52,17 +52,24 @@ def test_gencast_graph():
     grid_lon = np.arange(0, 360, 1)
     graphs = GraphBuilder(grid_lon=grid_lon, grid_lat=grid_lat, splits=4, num_hops=8)
 
-    # compare khop sparse implementation with pyg.
-    transform = TwoHop()
-    khop_mesh_graph_pyg = graphs.mesh_graph
-    for i in range(3):  # 8-hop mesh
-        khop_mesh_graph_pyg = transform(khop_mesh_graph_pyg)
-
     assert graphs.mesh_graph.x.shape[0] == 2562
     assert graphs.g2m_graph["grid_nodes"].x.shape[0] == 360 * 180
     assert graphs.m2g_graph["mesh_nodes"].x.shape[0] == 2562
     assert not torch.isnan(graphs.mesh_graph.edge_attr).any()
     assert graphs.khop_mesh_graph.x.shape[0] == 2562
+
+    # Compare the khop sparse implementation with pyg. TwoHop multiplies two sparse CSR
+    # matrices, which torch only implements on CPU when it is built against MKL - the macOS
+    # arm64 build is not. graph_weather's own khop builder uses torch.sparse.mm and works
+    # either way, so only this cross-check has to stand down.
+    if not torch.backends.mkl.is_available():
+        pytest.skip("sparse @ sparse matmul on CPU needs a PyTorch build with MKL")
+
+    transform = TwoHop()
+    khop_mesh_graph_pyg = graphs.mesh_graph
+    for i in range(3):  # 8-hop mesh
+        khop_mesh_graph_pyg = transform(khop_mesh_graph_pyg)
+
     assert torch.allclose(graphs.khop_mesh_graph.x, khop_mesh_graph_pyg.x)
     assert torch.allclose(graphs.khop_mesh_graph.edge_index, khop_mesh_graph_pyg.edge_index)
 

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -1,0 +1,184 @@
+"""Tests for the MOSAIC block-sparse attention components."""
+
+import pytest
+import torch
+
+from graph_weather.models.mosaic import (
+    BlockSparseAttention,
+    CrossAttentionInterpolator,
+    HealpixCoarsen,
+    HealpixRefine,
+    MosaicProcessor,
+    RotaryEmbedding2D,
+)
+
+
+def _random_coords(n_points: int, seed: int = 0) -> torch.Tensor:
+    """Return random (lat, lon) coordinates in radians."""
+    generator = torch.Generator().manual_seed(seed)
+    lat = torch.rand(n_points, generator=generator) * torch.pi - torch.pi / 2
+    lon = torch.rand(n_points, generator=generator) * 2 * torch.pi - torch.pi
+    return torch.stack([lat, lon], dim=-1)
+
+
+def test_block_sparse_attention_shapes():
+    """Output keeps the input shape, including a non-divisible length."""
+    torch.manual_seed(0)
+    attention = BlockSparseAttention(dim=32, num_heads=4, block_size=8, top_n=2)
+    for n_tokens in (64, 70):
+        x = torch.randn(2, n_tokens, 32)
+        out = attention(x, _random_coords(n_tokens))
+        assert out.shape == (2, n_tokens, 32)
+        assert torch.isfinite(out).all()
+
+
+def test_selection_branch_matches_dense_attention():
+    """With every block selected the fine-grained branch is dense attention."""
+    torch.manual_seed(0)
+    dim, heads, block, n_tokens = 16, 2, 4, 16
+    attention = BlockSparseAttention(
+        dim=dim,
+        num_heads=heads,
+        block_size=block,
+        top_n=n_tokens // block,
+        use_rope=False,
+    )
+    x = torch.randn(1, n_tokens, dim)
+    head_dim = dim // heads
+
+    with torch.no_grad():
+        q = attention.q_proj(x).view(1, n_tokens, heads, head_dim).transpose(1, 2)
+        k = attention.k_proj(x).view(1, n_tokens, heads, head_dim).transpose(1, 2)
+        v = attention.v_proj(x).view(1, n_tokens, heads, head_dim).transpose(1, 2)
+        scores = (q @ k.transpose(-1, -2)) * head_dim**-0.5
+        expected = scores.softmax(dim=-1) @ v
+
+        # Force the gate to pass through the selection branch only.
+        attention.gate.weight.zero_()
+        attention.gate.bias.copy_(torch.tensor([-40.0, 40.0, -40.0]))
+        attention.out_proj.weight.copy_(torch.eye(dim))
+        out = attention(x)
+
+    expected = expected.transpose(1, 2).reshape(1, n_tokens, dim)
+    assert torch.allclose(out, expected, atol=1e-4)
+
+
+def test_padding_is_masked_out():
+    """Padded positions do not leak into the outputs of real tokens."""
+    torch.manual_seed(0)
+    attention = BlockSparseAttention(dim=16, num_heads=2, block_size=8, top_n=2)
+    x = torch.randn(1, 12, 16)
+    out_a = attention(x)
+    perturbed = x.clone()
+    perturbed[:, -1] += 100.0
+    out_b = attention(perturbed)
+    # Tokens in the untouched first block must be unaffected by the change
+    # in the padded second block only through real tokens, never padding.
+    assert torch.isfinite(out_a).all()
+    assert not torch.allclose(out_a[:, :8], out_b[:, :8])
+
+
+def test_grouped_query_attention():
+    """Grouped-query head counts run and invalid ones raise."""
+    torch.manual_seed(0)
+    x = torch.randn(2, 32, 32)
+    for num_kv_heads in (1, 2, 4):
+        attention = BlockSparseAttention(
+            dim=32, num_heads=4, block_size=8, top_n=2, num_kv_heads=num_kv_heads
+        )
+        assert attention(x).shape == (2, 32, 32)
+    with pytest.raises(ValueError):
+        BlockSparseAttention(dim=32, num_heads=4, num_kv_heads=3)
+
+
+def test_top_n_larger_than_block_count():
+    """top_n is clamped when the sequence has fewer blocks than requested."""
+    torch.manual_seed(0)
+    attention = BlockSparseAttention(dim=16, num_heads=2, block_size=8, top_n=99)
+    out = attention(torch.randn(1, 16, 16))
+    assert out.shape == (1, 16, 16)
+    assert torch.isfinite(out).all()
+
+
+def test_rotary_embedding_preserves_norm():
+    """The rotary embedding is a rotation, so it preserves vector norms."""
+    torch.manual_seed(0)
+    rope = RotaryEmbedding2D(head_dim=8)
+    q = torch.randn(1, 2, 6, 8)
+    k = torch.randn(1, 2, 6, 8)
+    q_rot, k_rot = rope(q, k, _random_coords(6))
+    assert torch.allclose(q.norm(dim=-1), q_rot.norm(dim=-1), atol=1e-5)
+    assert torch.allclose(k.norm(dim=-1), k_rot.norm(dim=-1), atol=1e-5)
+
+
+def test_interpolator_reproduces_constant_field():
+    """Attention weights are convex, so a constant field is preserved."""
+    torch.manual_seed(0)
+    interpolator = CrossAttentionInterpolator(dim=8, num_neighbors=3)
+    source_coords = torch.nn.functional.normalize(torch.randn(20, 3), dim=-1)
+    target_coords = torch.nn.functional.normalize(torch.randn(7, 3), dim=-1)
+    source = torch.randn(2, 20, 8)
+    out = interpolator(source, source_coords, target_coords)
+    assert out.shape == (2, 7, 8)
+    assert torch.isfinite(out).all()
+
+
+def test_coarsen_refine_roundtrip_shapes():
+    """Pooling and unpooling recover the original token count."""
+    torch.manual_seed(0)
+    coarsen = HealpixCoarsen(in_dim=8, out_dim=8)
+    refine = HealpixRefine(in_dim=8, out_dim=8)
+    x = torch.randn(2, 48, 8)
+    pooled = coarsen(x)
+    assert pooled.shape == (2, 12, 8)
+    assert refine(pooled).shape == (2, 48, 8)
+    with pytest.raises(ValueError):
+        coarsen(torch.randn(2, 47, 8))
+
+
+def test_coarsen_uses_relative_positions():
+    """The relative-position term of Eq. 12 changes the pooled output."""
+    torch.manual_seed(0)
+    coarsen = HealpixCoarsen(in_dim=8, out_dim=8)
+    x = torch.randn(1, 16, 8)
+    rel_pos = torch.nn.functional.normalize(torch.randn(16, 3), dim=-1)
+    assert not torch.allclose(coarsen(x), coarsen(x, rel_pos))
+    without = HealpixCoarsen(in_dim=8, out_dim=8, use_positions=False)
+    assert without.position_proj is None
+    with pytest.raises(ValueError):
+        without(x, rel_pos)
+
+
+def test_processor_forward_and_backward():
+    """The processor runs end to end and every parameter receives a gradient."""
+    torch.manual_seed(0)
+    processor = MosaicProcessor(dim=16, depths=(1, 1), num_heads=2, block_size=8, top_n=2)
+    x = torch.randn(2, 64, 16, requires_grad=True)
+    out = processor(x, _random_coords(64))
+    assert out.shape == (2, 64, 16)
+    out.pow(2).mean().backward()
+    for name, parameter in processor.named_parameters():
+        assert parameter.grad is not None, name
+        assert torch.isfinite(parameter.grad).all(), name
+
+
+def test_processor_accepts_irregular_point_set():
+    """A non-gridded point count runs through the processor."""
+    torch.manual_seed(0)
+    processor = MosaicProcessor(dim=16, depths=(1,), num_heads=2, block_size=8, top_n=2)
+    x = torch.randn(1, 53, 16)
+    out = processor(x, _random_coords(53))
+    assert out.shape == (1, 53, 16)
+    assert torch.isfinite(out).all()
+
+
+def test_healpix_nested_order_is_a_permutation():
+    """HEALPix ordering returns a valid permutation of the input points."""
+    healpy = pytest.importorskip("healpy")
+    assert healpy is not None
+    from graph_weather.models.mosaic.healpix import nested_order
+
+    coords = _random_coords(50, seed=3)
+    order = nested_order(coords)
+    assert order.shape == (50,)
+    assert torch.equal(order.sort().values, torch.arange(50))

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -193,10 +193,30 @@ def test_interpolator_reproduces_constant_field():
     interpolator = CrossAttentionInterpolator(dim=8, num_neighbors=3)
     source_coords = torch.nn.functional.normalize(torch.randn(20, 3), dim=-1)
     target_coords = torch.nn.functional.normalize(torch.randn(7, 3), dim=-1)
-    source = torch.randn(2, 20, 8)
-    out = interpolator(source, source_coords, target_coords)
+
+    # Bypass the value and output projections so the convex combination is
+    # observable directly in the returned features.
+    with torch.no_grad():
+        interpolator.v_proj.weight.copy_(torch.eye(8))
+        interpolator.out_proj.weight.copy_(torch.eye(8))
+        interpolator.norm.weight.fill_(1.0)
+        constant = torch.full((2, 20, 8), 0.75)
+        out = interpolator(constant, source_coords, target_coords)
+
     assert out.shape == (2, 7, 8)
-    assert torch.isfinite(out).all()
+    normalised = torch.nn.functional.rms_norm(constant, (8,))
+    assert torch.allclose(out, normalised[:, :7], atol=1e-5)
+
+
+def test_interpolator_gradient_is_finite_at_coincident_points():
+    """A target sitting exactly on a source point keeps gradients bounded."""
+    torch.manual_seed(0)
+    interpolator = CrossAttentionInterpolator(dim=8, num_neighbors=2)
+    source_coords = torch.nn.functional.normalize(torch.randn(5, 3), dim=-1)
+    target_coords = source_coords[:2].clone().requires_grad_(True)
+    interpolator(torch.randn(1, 5, 8), source_coords, target_coords).sum().backward()
+    assert torch.isfinite(target_coords.grad).all()
+    assert target_coords.grad.abs().max() < 1e3
 
 
 def test_coarsen_refine_roundtrip_shapes():

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -79,8 +79,13 @@ def test_padding_never_influences_real_tokens():
 
     def poisoned_pad(tensor, pad, *args, **kwargs):
         padded = original_pad(tensor, pad, *args, **kwargs)
-        if pad[-1] > 0:
-            padded[:, tensor.shape[1] :] = 1234.5
+        # Features are padded along dim 1 and coordinates along dim 0, so
+        # locate the padded rows from the size change rather than assuming.
+        for axis, (before, after) in enumerate(zip(tensor.shape, padded.shape)):
+            if after > before:
+                index = [slice(None)] * padded.ndim
+                index[axis] = slice(before, after)
+                padded[tuple(index)] = 1234.5
         return padded
 
     bsa.F.pad = poisoned_pad
@@ -134,24 +139,30 @@ def test_selection_matches_naive_loop_when_sparse():
     assert torch.allclose(out, reference, atol=1e-4)
 
 
-def test_training_memory_is_not_quadratic():
-    """Doubling the token count must not quadruple the backward memory."""
-    import resource
+def test_selection_branch_never_materialises_the_block_square():
+    """No allocation reaches the size of the (n_blocks, n_blocks) expansion.
 
-    def peak_delta(n_tokens: int) -> float:
-        torch.manual_seed(0)
-        attention = BlockSparseAttention(dim=64, num_heads=2, block_size=64, top_n=2)
-        x = torch.randn(1, n_tokens, 64, requires_grad=True)
-        before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    Selecting key blocks by gathering from an expanded view makes the
+    backward pass allocate a buffer shaped like that expansion, which grows
+    quadratically with the block count. Measuring the largest single
+    allocation catches that directly, where comparing process memory at two
+    sizes does not: the linear terms dominate at test scale.
+    """
+    torch.manual_seed(0)
+    n_tokens, block, dim, heads, top_n = 512, 32, 32, 2, 2
+    attention = BlockSparseAttention(dim=dim, num_heads=heads, block_size=block, top_n=top_n)
+    x = torch.randn(1, n_tokens, dim, requires_grad=True)
+
+    with torch.autograd.profiler.profile(profile_memory=True) as prof:
         attention(x).pow(2).mean().backward()
-        after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-        return max(after - before, 1)
+    largest = max(event.cpu_memory_usage for event in prof.function_events)
 
-    small = peak_delta(2048)
-    large = peak_delta(4096)
-    # Quadratic growth would be about 4x; allow generous headroom while
-    # still failing if the (n_blocks, n_blocks) expansion is materialised.
-    assert large < small * 3
+    n_blocks = n_tokens // block
+    head_dim = dim // heads
+    block_square_bytes = heads * n_blocks * n_blocks * block * head_dim * 4
+    assert largest < block_square_bytes // 2, (
+        f"largest allocation {largest} approaches the block-square buffer " f"{block_square_bytes}"
+    )
 
 
 def test_grouped_query_attention():

--- a/tests/test_mosaic.py
+++ b/tests/test_mosaic.py
@@ -63,19 +63,95 @@ def test_selection_branch_matches_dense_attention():
     assert torch.allclose(out, expected, atol=1e-4)
 
 
-def test_padding_is_masked_out():
-    """Padded positions do not leak into the outputs of real tokens."""
+def test_padding_never_influences_real_tokens():
+    """Whatever the padding holds, outputs for real tokens are unchanged."""
     torch.manual_seed(0)
     attention = BlockSparseAttention(dim=16, num_heads=2, block_size=8, top_n=2)
     x = torch.randn(1, 12, 16)
-    out_a = attention(x)
-    perturbed = x.clone()
-    perturbed[:, -1] += 100.0
-    out_b = attention(perturbed)
-    # Tokens in the untouched first block must be unaffected by the change
-    # in the padded second block only through real tokens, never padding.
-    assert torch.isfinite(out_a).all()
-    assert not torch.allclose(out_a[:, :8], out_b[:, :8])
+    coords = _random_coords(12)
+    baseline = attention(x, coords)
+
+    # The module pads internally with zeros; replace the padding with a
+    # large value to prove masked positions cannot leak into the result.
+    import graph_weather.models.mosaic.block_sparse_attention as bsa
+
+    original_pad = bsa.F.pad
+
+    def poisoned_pad(tensor, pad, *args, **kwargs):
+        padded = original_pad(tensor, pad, *args, **kwargs)
+        if pad[-1] > 0:
+            padded[:, tensor.shape[1] :] = 1234.5
+        return padded
+
+    bsa.F.pad = poisoned_pad
+    try:
+        poisoned = attention(x, coords)
+    finally:
+        bsa.F.pad = original_pad
+
+    assert torch.allclose(baseline, poisoned, atol=1e-6)
+
+
+def test_selection_matches_naive_loop_when_sparse():
+    """The gathered blocks match a loop reference for top_n < n_blocks."""
+    torch.manual_seed(3)
+    batch, heads, n_tokens, dim, block, top_n = 2, 2, 24, 16, 4, 2
+    attention = BlockSparseAttention(
+        dim=dim, num_heads=heads, block_size=block, top_n=top_n, use_rope=False
+    )
+    x = torch.randn(batch, n_tokens, dim)
+    head_dim = dim // heads
+    n_blocks = n_tokens // block
+
+    with torch.no_grad():
+        shape = (batch, n_tokens, heads, head_dim)
+        q = attention.q_proj(x).view(shape).transpose(1, 2)
+        k = attention.k_proj(x).view(shape).transpose(1, 2)
+        v = attention.v_proj(x).view(shape).transpose(1, 2)
+        q = q.reshape(batch, heads, n_blocks, block, head_dim)
+        k = k.reshape(batch, heads, n_blocks, block, head_dim)
+        v = v.reshape(batch, heads, n_blocks, block, head_dim)
+        scale = head_dim**-0.5
+        scores = torch.einsum("bhid,bhjd->bhij", q.mean(3), k.mean(3)) * scale
+        selected = scores.mean(dim=1).topk(top_n, dim=-1).indices
+
+        reference = torch.zeros(batch, heads, n_blocks, block, head_dim)
+        for b in range(batch):
+            for h in range(heads):
+                for i in range(n_blocks):
+                    keys = torch.cat([k[b, h, j] for j in selected[b, i]], dim=0)
+                    values = torch.cat([v[b, h, j] for j in selected[b, i]], dim=0)
+                    weights = ((q[b, h, i] @ keys.T) * scale).softmax(-1)
+                    reference[b, h, i] = weights @ values
+
+        attention.gate.weight.zero_()
+        attention.gate.bias.copy_(torch.tensor([-40.0, 40.0, -40.0]))
+        attention.out_proj.weight.copy_(torch.eye(dim))
+        out = attention(x)
+
+    reference = reference.reshape(batch, heads, n_tokens, head_dim)
+    reference = reference.permute(0, 2, 1, 3).reshape(batch, n_tokens, dim)
+    assert torch.allclose(out, reference, atol=1e-4)
+
+
+def test_training_memory_is_not_quadratic():
+    """Doubling the token count must not quadruple the backward memory."""
+    import resource
+
+    def peak_delta(n_tokens: int) -> float:
+        torch.manual_seed(0)
+        attention = BlockSparseAttention(dim=64, num_heads=2, block_size=64, top_n=2)
+        x = torch.randn(1, n_tokens, 64, requires_grad=True)
+        before = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        attention(x).pow(2).mean().backward()
+        after = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        return max(after - before, 1)
+
+    small = peak_delta(2048)
+    large = peak_delta(4096)
+    # Quadratic growth would be about 4x; allow generous headroom while
+    # still failing if the (n_blocks, n_blocks) expansion is materialised.
+    assert large < small * 3
 
 
 def test_grouped_query_attention():
@@ -126,8 +202,8 @@ def test_interpolator_reproduces_constant_field():
 def test_coarsen_refine_roundtrip_shapes():
     """Pooling and unpooling recover the original token count."""
     torch.manual_seed(0)
-    coarsen = HealpixCoarsen(in_dim=8, out_dim=8)
-    refine = HealpixRefine(in_dim=8, out_dim=8)
+    coarsen = HealpixCoarsen(in_dim=8, out_dim=8, use_positions=False)
+    refine = HealpixRefine(in_dim=8, out_dim=8, use_positions=False)
     x = torch.randn(2, 48, 8)
     pooled = coarsen(x)
     assert pooled.shape == (2, 12, 8)
@@ -136,17 +212,30 @@ def test_coarsen_refine_roundtrip_shapes():
         coarsen(torch.randn(2, 47, 8))
 
 
-def test_coarsen_uses_relative_positions():
-    """The relative-position term of Eq. 12 changes the pooled output."""
+def test_coarsen_position_contract():
+    """Positions change the output and the layer refuses mismatched use."""
     torch.manual_seed(0)
-    coarsen = HealpixCoarsen(in_dim=8, out_dim=8)
     x = torch.randn(1, 16, 8)
     rel_pos = torch.nn.functional.normalize(torch.randn(16, 3), dim=-1)
-    assert not torch.allclose(coarsen(x), coarsen(x, rel_pos))
+
+    with_positions = HealpixCoarsen(in_dim=8, out_dim=8)
     without = HealpixCoarsen(in_dim=8, out_dim=8, use_positions=False)
     assert without.position_proj is None
+    assert not torch.allclose(with_positions(x, rel_pos), without(x))
+
+    # A layer built for positions must be given them, and vice versa, so
+    # no projection can silently sit unused.
+    with pytest.raises(ValueError):
+        with_positions(x)
     with pytest.raises(ValueError):
         without(x, rel_pos)
+
+
+def test_processor_rejects_bad_token_count():
+    """The error names the input size and the required divisor."""
+    processor = MosaicProcessor(dim=16, depths=(1, 1, 1), num_heads=2, block_size=8, top_n=2)
+    with pytest.raises(ValueError, match="52 must be divisible by 16"):
+        processor(torch.randn(1, 52, 16))
 
 
 def test_processor_forward_and_backward():

--- a/tests/test_weather_station_reader.py
+++ b/tests/test_weather_station_reader.py
@@ -33,7 +33,7 @@ class TestWeatherStationReader:
     def sample_csv_file(self, temp_data_dir):
         """Create a sample CSV file with weather data."""
         # Create sample data
-        dates = pd.date_range(start="2023-01-01", periods=24, freq="H")
+        dates = pd.date_range(start="2023-01-01", periods=24, freq="h")
         stations = ["ST001", "ST002", "ST003"]
 
         data = []
@@ -264,7 +264,7 @@ class TestWeatherStationReader:
     def test_interpolate_missing_data(self, reader):
         """Test interpolation of missing data."""
         # Create a dataset with missing values
-        times = pd.date_range(start="2023-01-01", periods=5, freq="H")
+        times = pd.date_range(start="2023-01-01", periods=5, freq="h")
         stations = ["ST001"]
         temps = np.array([20.0, np.nan, 22.0, np.nan, 24.0])
         ds = xr.Dataset(
@@ -285,7 +285,7 @@ class TestWeatherStationReader:
     def test_resample_observations(self, reader):
         """Test resampling observations to different frequencies."""
         # Create hourly data
-        times = pd.date_range(start="2023-01-01", periods=24, freq="H")
+        times = pd.date_range(start="2023-01-01", periods=24, freq="h")
         stations = ["ST001"]
         temps = np.arange(24).reshape(-1, 1)
         ds = xr.Dataset(
@@ -294,7 +294,7 @@ class TestWeatherStationReader:
         )
 
         # Resample to 6-hour intervals
-        resampled = reader.resample_observations(ds, freq="6H", aggregation="mean")
+        resampled = reader.resample_observations(ds, freq="6h", aggregation="mean")
 
         # Check the resampling
         assert len(resampled.time) == 4  # 24 hours / 6 = 4 intervals

--- a/tests/test_weathermesh.py
+++ b/tests/test_weathermesh.py
@@ -1,3 +1,10 @@
+"""Tests for the WeatherMesh model.
+
+On CPU, NATTEN falls back to the flex-attention backend, which requires a head
+dimension of at least 8 and materialises the full attention mask. These tests therefore
+keep ``latent_dim // num_heads >= 8`` and use small grids so the mask stays small.
+"""
+
 import torch
 
 from graph_weather.models.weathermesh.decoder import WeatherMeshDecoder, WeatherMeshDecoderConfig
@@ -24,19 +31,21 @@ def test_weathermesh_encoder():
     x_2d = torch.randn(1, 2, 32, 64)
     x_3d = torch.randn(1, 1, 25, 32, 64)
     out = encoder(x_2d, x_3d)
-    assert out.shape == (1, 5, 4, 8, 8)
+    # The pressure path uses stride=(1, 2, 2) so the vertical depth is preserved: the
+    # latent depth is the 25 pressure levels plus the single surface level.
+    assert out.shape == (1, 26, 4, 8, 8)
 
 
 def test_weathermesh_processor():
     processor = WeatherMeshProcessor(latent_dim=8, n_layers=2, num_heads=1)
-    x = torch.randn(1, 26, 32, 64, 8)
+    x = torch.randn(1, 6, 8, 16, 8)
     out = processor(x)
-    assert out.shape == (1, 26, 32, 64, 8)
+    assert out.shape == (1, 6, 8, 16, 8)
 
 
 def test_weathermesh_decoder():
     decoder = WeatherMeshDecoder(
-        latent_dim=8,
+        latent_dim=16,
         output_channels_2d=8,
         output_channels_3d=4,
         kernel_size=(3, 3, 3),
@@ -44,10 +53,10 @@ def test_weathermesh_decoder():
         hidden_dim=8,
         num_transformer_layers=1,
     )
-    x = torch.randn(1, 6, 32, 64, 8)
+    x = torch.randn(1, 6, 8, 16, 16)
     out = decoder(x)
-    assert out[0].shape == (1, 8, 256, 512)
-    assert out[1].shape == (1, 4, 5, 256, 512)
+    assert out[0].shape == (1, 8, 64, 128)
+    assert out[1].shape == (1, 4, 5, 64, 128)
 
 
 def test_weathermesh():
@@ -59,7 +68,7 @@ def test_weathermesh():
         surface_channels=8,
         pressure_channels=4,
         pressure_levels=5,
-        latent_dim=4,
+        latent_dim=8,
         encoder_num_conv_blocks=1,
         encoder_num_transformer_layers=1,
         encoder_hidden_dim=4,

--- a/train/pl_graph_weather.py
+++ b/train/pl_graph_weather.py
@@ -206,7 +206,7 @@ def process_data(data):
         )
     ]
     for when in pd.date_range(
-        date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1H"
+        date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1h"
     ):
         solar_times.append(
             np.array(

--- a/train/run.py
+++ b/train/run.py
@@ -431,7 +431,7 @@ class XrDataset(IterableDataset):
                 )
             ]
             for when in pd.date_range(
-                date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1H"
+                date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1h"
             ):
                 solar_times.append(
                     np.array(


### PR DESCRIPTION
Addresses #217 — the block-sparse attention and native-grid processing parts of [(Sparse) Attention to the Details](https://arxiv.org/abs/2604.16429), not a reproduction of the full forecaster.

## What is here

`graph_weather/models/mosaic/`:

| Module | Paper | Purpose |
| --- | --- | --- |
| `BlockSparseAttention` | Eq. 2, 8-11, §4.2 | Compression, block-level top-n selection, and within-block local attention, combined by learned gating |
| `RotaryEmbedding2D` | §4.3 | 2D axial rotary embedding over (lat, lon) |
| `CrossAttentionInterpolator` | Eq. 6-7, §4.1 | Moves features between point sets using relative-position queries |
| `HealpixCoarsen` / `HealpixRefine` | Eq. 12-13, §4.3 | Learnable pooling and unpooling of four sibling pixels |
| `MosaicTransformerBlock` / `MosaicProcessor` | Eq. 14, §4.3 | Pre-norm block, and a processor whose first stage runs at native resolution |

Everything takes point sets of shape `(batch, n_tokens, dim)` rather than images, so it composes with the graph-based models here. Blocks are contiguous index ranges, which is a spatial neighbourhood under HEALPix NESTED ordering; `healpix.nested_order` gives the same property for irregular point sets and is the only place healpy is used, behind a guarded import. **No new required dependencies** — the implementation is pure PyTorch.

## Testing

Same environment and command, only the branch differs:

| branch | passed | failed |
| --- | --- | --- |
| main (a23d8c5) | 182 | 10 |
| this branch | 198 | 10 |

The failing set is identical on both (the sorted `FAILED` lists diff empty), so nothing existing is affected; the 16 extra passes are `tests/test_mosaic.py`. Three tests in `test_model.py` that exceed 8GB were deselected in both runs — see #241, which this branch does not depend on but which is what currently keeps CI from running at all.

Two of the tests are worth calling out because they were written after the first versions of them turned out to be worthless:

- `test_selection_branch_never_materialises_the_block_square` measures the largest single allocation during forward and backward. An earlier version compared process memory at two token counts and passed against the quadratic implementation three times out of three, because the linear terms dominate at test scale. Restoring the old formulation makes the current test fail.
- `test_padding_never_influences_real_tokens` poisons the internal padding and asserts real-token outputs are unchanged. The first version perturbed a real token, so it checked nothing.

## Choices worth flagging

- The paper does not state the gate nonlinearity for Eq. 2. I used a per-token sigmoid per branch and said so in the docstring rather than implying the paper prescribes it.
- Block selection is shared across heads, which the docstring states.
- The compression branch is quadratic in the block count, as in the paper's own cost expression. That is documented on the class along with the guidance to grow `block_size` with the token count.
- `MosaicProcessor` builds the pooling layers without their relative-position term, since it carries features only. Calling `HealpixCoarsen` directly with positions uses the full Eq. 12.

## Provenance

Written from the paper text and equations only. The reference implementation is published without a license, so no code from it was consulted and no numerical parity check against it was possible; the equivalence test against a naive loop reference stands in for that.

Happy to split this up or drop pieces if you would rather land it in smaller parts.