### PR TITLE
style: fix the 156 ruff errors that keep pre-commit.ci red on main (#244)

### DIFF
--- a/graph_weather/data/anemoi_dataloader.py
+++ b/graph_weather/data/anemoi_dataloader.py
@@ -1,3 +1,10 @@
+"""PyTorch dataset wrapper around Anemoi datasets.
+
+Loads an Anemoi dataset through ``anemoi.datasets.open_dataset``, normalizes the requested
+atmospheric variables with caller-supplied means and standard deviations, and appends
+sine/cosine clock features for the day of year and the hour of day.
+"""
+
 import logging
 
 import numpy as np
@@ -31,6 +38,23 @@ class AnemoiDataset(Dataset):
         max_samples: int = None,
         **kwargs,
     ):
+        """Open the Anemoi dataset and validate the features and grid coordinates.
+
+        Args:
+            dataset_name: Name of the Anemoi dataset (e.g. "era5-o48-2020-2021-6h-v1").
+            features: List of atmospheric variables to use.
+            means: Dict of means for each feature; an entry is required for every feature.
+            stds: Dict of standard deviations for each feature; one is required per feature.
+            time_range: Optional tuple of (start_date, end_date) added to the dataset config.
+            time_step: Number of time indices between the input sample and the target sample.
+            max_samples: Optional cap on the number of samples reported by ``__len__``.
+            **kwargs: Extra keys merged into the ``open_dataset`` configuration.
+
+        Raises:
+            ValueError: If normalization statistics are missing, a requested feature is not
+                present in the dataset, or latitude/longitude coordinates cannot be found.
+            RuntimeError: If the underlying Anemoi dataset fails to load.
+        """
         super().__init__()
 
         self.features = features

--- a/graph_weather/models/aurora/__init__.py
+++ b/graph_weather/models/aurora/__init__.py
@@ -1,5 +1,6 @@
 """
 Aurora: A Foundation Model for Earth System Science
+
 - Combines 3D Swin Transformer encoding
 - Perceiver processing for efficient computation
 - 3D decoding for spatial-temporal predictions

--- a/graph_weather/models/aurora/decoder.py
+++ b/graph_weather/models/aurora/decoder.py
@@ -1,5 +1,6 @@
 """
-3D Decoder:
+3D Decoder
+
 - Takes processed latent representations and reconstructs output.
 - Uses transposed convolution to upscale back to spatial-temporal format.
 """
@@ -9,13 +10,16 @@ import torch.nn as nn
 
 class Decoder3D(nn.Module):
     """
-    3D Decoder:
+    3D Decoder
+
     - Takes processed latent representations and reconstructs the spatial-temporal output.
     - Uses transposed convolutions to upscale latent features to the original format.
     """
 
     def __init__(self, output_channels=1, embed_dim=96, target_shape=(32, 32, 32)):
         """
+        Initialize the decoder.
+
         Args:
             output_channels (int): Number of channels in the output tensor (e.g., 1 for grayscale).
             embed_dim (int): Dimension of the latent features (matches the encoder's output).

--- a/graph_weather/models/aurora/decoder.py
+++ b/graph_weather/models/aurora/decoder.py
@@ -13,7 +13,10 @@ class Decoder3D(nn.Module):
     3D Decoder
 
     - Takes processed latent representations and reconstructs the spatial-temporal output.
-    - Uses transposed convolutions to upscale latent features to the original format.
+    - Uses a transposed convolution to map latent features to the output channels. With
+      ``kernel_size=3``, ``stride=1`` and ``padding=1`` the depth, height and width of the
+      reshaped latent are preserved, so the spatial-temporal size comes from
+      ``target_shape``.
     """
 
     def __init__(self, output_channels=1, embed_dim=96, target_shape=(32, 32, 32)):

--- a/graph_weather/models/aurora/encoder.py
+++ b/graph_weather/models/aurora/encoder.py
@@ -1,5 +1,6 @@
 """
-Swin 3D Transformer Encoder:
+Swin 3D Transformer Encoder
+
 - Uses a 3D convolution for initial feature extraction.
 - Applies layer normalization and reshapes data.
 - Uses a transformer-based encoder to learn spatial-temporal features.
@@ -11,7 +12,22 @@ from einops.layers.torch import Rearrange
 
 
 class Swin3DEncoder(nn.Module):
+    """
+    Encode 3D volumetric data into a sequence of per-voxel embeddings.
+
+    A 3D convolution extracts local features, layer normalization is applied over the
+    channel dimension, and the flattened voxel sequence is passed through the encoder
+    stack of a ``torch.nn.Transformer``.
+    """
+
     def __init__(self, in_channels=1, embed_dim=96):
+        """
+        Initialize the encoder.
+
+        Args:
+            in_channels (int): Number of channels in the input volume.
+            embed_dim (int): Size of the embedding produced for each voxel.
+        """
         super().__init__()
         self.conv1 = nn.Conv3d(in_channels, embed_dim, kernel_size=3, padding=1, stride=1)
         self.norm = nn.LayerNorm(embed_dim)
@@ -30,6 +46,15 @@ class Swin3DEncoder(nn.Module):
 
     # To use rearrange function directly instead of the Rearrange layer
     def forward(self, x):
+        """
+        Encode an input volume into a sequence of embeddings.
+
+        Args:
+            x (torch.Tensor): Input volume of shape (batch, in_channels, depth, height, width).
+
+        Returns:
+            torch.Tensor: Encoded sequence of shape (batch, depth * height * width, embed_dim).
+        """
         # 3D convolution with einops rearrangement
         x = self.conv1(x)
 

--- a/graph_weather/models/aurora/model.py
+++ b/graph_weather/models/aurora/model.py
@@ -12,9 +12,10 @@ class PointEncoder(nn.Module):
     """
     Embed unstructured points and their features into a common latent space.
 
-    Coordinates and features are embedded by two separate multi-layer perceptrons and are
-    combined by addition, an order-invariant operation. No positional embeddings are used,
-    so the result does not depend on the ordering of the points.
+    Coordinates and features are embedded by two separate point-wise multi-layer
+    perceptrons and combined by addition. No positional embeddings are used, so the
+    mapping is permutation-equivariant: reordering the input points reorders the output
+    embeddings and changes nothing else.
     """
 
     def __init__(self, input_features: int, embed_dim: int, max_seq_len: int = 1024):
@@ -373,7 +374,10 @@ class AuroraModel(nn.Module):
                 positions are zeroed in the inputs and in the output.
 
         Returns:
-            torch.Tensor: Predictions of shape (batch_size, num_points, output_features).
+            torch.Tensor: Predictions of shape
+            (batch_size, min(num_points, max_seq_len), output_features). The encoder
+            truncates to ``max_seq_len``, which may be smaller than ``max_points``, so a
+            longer ``mask`` does not line up with the output.
 
         Raises:
             ValueError: If the number of points exceeds ``max_points``.

--- a/graph_weather/models/aurora/model.py
+++ b/graph_weather/models/aurora/model.py
@@ -9,7 +9,24 @@ import torch.nn as nn
 
 
 class PointEncoder(nn.Module):
+    """
+    Embed unstructured points and their features into a common latent space.
+
+    Coordinates and features are embedded by two separate multi-layer perceptrons and are
+    combined by addition, an order-invariant operation. No positional embeddings are used,
+    so the result does not depend on the ordering of the points.
+    """
+
     def __init__(self, input_features: int, embed_dim: int, max_seq_len: int = 1024):
+        """
+        Initialize the point encoder.
+
+        Args:
+            input_features (int): Number of feature channels attached to each point.
+            embed_dim (int): Size of the embedding produced for each point.
+            max_seq_len (int): Maximum number of points kept per sample. Longer inputs are
+                truncated in ``forward``.
+        """
         super().__init__()
         self.input_dim = input_features + 2  # Account for lat/lon coordinates
         self.max_seq_len = max_seq_len
@@ -36,6 +53,18 @@ class PointEncoder(nn.Module):
         self.norm = nn.LayerNorm(embed_dim)
 
     def forward(self, points: torch.Tensor, features: torch.Tensor) -> torch.Tensor:
+        """
+        Encode point coordinates and point features into a single embedding per point.
+
+        Args:
+            points (torch.Tensor): Coordinates of shape (batch_size, num_points, 2), given as
+                (longitude, latitude) in degrees.
+            features (torch.Tensor): Features of shape (batch_size, num_points, input_features).
+
+        Returns:
+            torch.Tensor: Embeddings of shape (batch_size, num_points, embed_dim). Inputs
+            longer than ``max_seq_len`` are truncated to their first ``max_seq_len`` points.
+        """
         num_points = points.shape[1]
         if num_points > self.max_seq_len:
             points = points[:, : self.max_seq_len, :]
@@ -64,6 +93,13 @@ class PointDecoder(nn.Module):
     """Decodes latent representations back to point features."""
 
     def __init__(self, embed_dim: int, output_features: int):
+        """
+        Initialize the point decoder.
+
+        Args:
+            embed_dim (int): Size of the latent embedding of each point.
+            output_features (int): Number of feature channels produced for each point.
+        """
         super().__init__()
         self.decoder = nn.Sequential(
             nn.Linear(embed_dim, embed_dim), nn.ReLU(), nn.Linear(embed_dim, output_features)
@@ -71,8 +107,11 @@ class PointDecoder(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
+        Decode latent point embeddings into output features.
+
         Args:
             x: (batch_size, num_points, embed_dim) tensor
+
         Returns:
             (batch_size, num_points, output_features) tensor
         """
@@ -83,13 +122,23 @@ class PointCloudProcessor(nn.Module):
     """Processes point cloud data using self-attention layers."""
 
     def __init__(self, embed_dim: int, num_layers: int = 4):
+        """
+        Initialize the point cloud processor.
+
+        Args:
+            embed_dim (int): Size of the latent embedding of each point.
+            num_layers (int): Number of stacked self-attention layers.
+        """
         super().__init__()
         self.layers = nn.ModuleList([SelfAttentionLayer(embed_dim) for _ in range(num_layers)])
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
+        Apply the stack of self-attention layers to the point embeddings.
+
         Args:
             x: (batch_size, num_points, embed_dim) tensor
+
         Returns:
             (batch_size, num_points, embed_dim) tensor after processing
         """
@@ -99,7 +148,21 @@ class PointCloudProcessor(nn.Module):
 
 
 class SelfAttentionLayer(nn.Module):
+    """
+    Transformer block combining multi-head self-attention and a feed-forward network.
+
+    Each of the two sub-blocks is wrapped in a residual connection followed by layer
+    normalization.
+    """
+
     def __init__(self, embed_dim: int):
+        """
+        Initialize the self-attention layer.
+
+        Args:
+            embed_dim (int): Size of the per-point embedding, also used as the attention
+                model dimension. The layer uses 8 attention heads.
+        """
         super().__init__()
         self.attention = nn.MultiheadAttention(embed_dim, num_heads=8)
         self.norm1 = nn.LayerNorm(embed_dim)
@@ -109,6 +172,18 @@ class SelfAttentionLayer(nn.Module):
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Apply self-attention and the feed-forward network with residual connections.
+
+        The input is transposed internally because ``nn.MultiheadAttention`` is created with
+        its default sequence-first layout.
+
+        Args:
+            x (torch.Tensor): Point embeddings of shape (batch_size, num_points, embed_dim).
+
+        Returns:
+            torch.Tensor: Updated embeddings of shape (batch_size, num_points, embed_dim).
+        """
         # First attention block with residual
         x_t = x.transpose(0, 1)
         attended, _ = self.attention(x_t, x_t, x_t)
@@ -121,7 +196,23 @@ class SelfAttentionLayer(nn.Module):
 
 
 class EarthSystemLoss(nn.Module):
+    """
+    Composite loss for point-wise Earth system predictions.
+
+    It sums a mean squared error term, a spatial correlation term that compares the
+    differences between nearby points, and a physical consistency term, weighted by
+    ``alpha``, ``beta`` and ``gamma`` respectively.
+    """
+
     def __init__(self, alpha: float = 0.5, beta: float = 0.3, gamma: float = 0.2):
+        """
+        Initialize the loss weights.
+
+        Args:
+            alpha (float): Weight of the mean squared error term.
+            beta (float): Weight of the spatial correlation term.
+            gamma (float): Weight of the physical consistency term.
+        """
         super().__init__()
         self.alpha = alpha
         self.beta = beta
@@ -130,6 +221,21 @@ class EarthSystemLoss(nn.Module):
     def spatial_correlation_loss(
         self, pred: torch.Tensor, target: torch.Tensor, points: torch.Tensor
     ) -> torch.Tensor:
+        """
+        Penalize disagreement between predicted and target differences of nearby points.
+
+        Distances are Euclidean in the raw (longitude, latitude) coordinates and pairs of
+        points closer than 5 degrees are treated as neighboring.
+
+        Args:
+            pred (torch.Tensor): Predictions of shape (batch_size, num_points, features).
+            target (torch.Tensor): Targets of shape (batch_size, num_points, features).
+            points (torch.Tensor): Coordinates of shape (batch_size, num_points, 2).
+
+        Returns:
+            torch.Tensor: Scalar tensor with the mean squared difference taken over the
+            neighboring point pairs.
+        """
         batch_size, num_points, _ = points.shape
         points_flat = points.view(-1, 2)
 
@@ -169,6 +275,18 @@ class EarthSystemLoss(nn.Module):
         return physical_loss
 
     def forward(self, pred: torch.Tensor, target: torch.Tensor, points: torch.Tensor) -> dict:
+        """
+        Compute the weighted total loss together with each of its terms.
+
+        Args:
+            pred (torch.Tensor): Predictions of shape (batch_size, num_points, features).
+            target (torch.Tensor): Targets of shape (batch_size, num_points, features).
+            points (torch.Tensor): Coordinates of shape (batch_size, num_points, 2).
+
+        Returns:
+            dict: Mapping with the keys ``total_loss``, ``mse_loss``,
+            ``spatial_correlation_loss`` and ``physical_loss``, each holding a scalar tensor.
+        """
         mse_loss = torch.nn.functional.mse_loss(pred, target)
         spatial_loss = self.spatial_correlation_loss(pred, target, points)
         physical_loss = self.physical_loss(pred, points)
@@ -185,6 +303,13 @@ class EarthSystemLoss(nn.Module):
 
 
 class AuroraModel(nn.Module):
+    """
+    Encoder-processor-decoder model for predicting features on unstructured points.
+
+    Points and their features are embedded by ``PointEncoder``, refined by
+    ``PointCloudProcessor`` and mapped back to feature space by ``PointDecoder``.
+    """
+
     def __init__(
         self,
         input_features: int,
@@ -195,6 +320,19 @@ class AuroraModel(nn.Module):
         max_seq_len: int = 1024,
         use_checkpointing: bool = False,
     ):
+        """
+        Initialize the model and its encoder, processor and decoder.
+
+        Args:
+            input_features (int): Number of feature channels attached to each input point.
+            output_features (int): Number of feature channels predicted for each point.
+            latent_dim (int): Size of the latent embedding used throughout the model.
+            num_layers (int): Number of self-attention layers in the processor.
+            max_points (int): Maximum number of points accepted by ``forward``.
+            max_seq_len (int): Maximum number of points kept by the encoder.
+            use_checkpointing (bool): Whether to run the processor under gradient
+                checkpointing during training to save memory.
+        """
         super().__init__()
 
         self.max_points = max_points
@@ -223,6 +361,22 @@ class AuroraModel(nn.Module):
     def forward(
         self, points: torch.Tensor, features: torch.Tensor, mask: Optional[torch.Tensor] = None
     ) -> torch.Tensor:
+        """
+        Predict output features for a batch of points.
+
+        Args:
+            points (torch.Tensor): Coordinates of shape (batch_size, num_points, 2), given as
+                (longitude, latitude) in degrees.
+            features (torch.Tensor): Features of shape (batch_size, num_points, input_features).
+            mask (Optional[torch.Tensor]): Mask of shape (batch_size, num_points). Masked
+                positions are zeroed in the inputs and in the output.
+
+        Returns:
+            torch.Tensor: Predictions of shape (batch_size, num_points, output_features).
+
+        Raises:
+            ValueError: If the number of points exceeds ``max_points``.
+        """
         if points.shape[1] > self.max_points:
             raise ValueError(
                 f"Number of points ({points.shape[1]}) exceeds maximum ({self.max_points})"

--- a/graph_weather/models/aurora/model.py
+++ b/graph_weather/models/aurora/model.py
@@ -233,8 +233,9 @@ class EarthSystemLoss(nn.Module):
             points (torch.Tensor): Coordinates of shape (batch_size, num_points, 2).
 
         Returns:
-            torch.Tensor: Scalar tensor with the mean squared difference taken over the
-            neighboring point pairs.
+            torch.Tensor: Scalar tensor. Squared differences are zeroed outside the
+            neighborhood and then averaged over every pair, so the value scales with
+            the fraction of pairs that are neighboring.
         """
         batch_size, num_points, _ = points.shape
         points_flat = points.view(-1, 2)

--- a/graph_weather/models/aurora/processor.py
+++ b/graph_weather/models/aurora/processor.py
@@ -20,7 +20,9 @@ class ProcessorConfig:
     Architecture configuration for ``PerceiverProcessor``.
 
     Attributes:
-        input_dim: Number of channels of the incoming features, matching the Swin3D output.
+        input_dim: Number of channels of the incoming features. It has to match the width
+            produced by the encoder, which `Swin3DEncoder` defaults to 96, so one of the
+            two defaults must be overridden for the pair to compose.
         latent_dim: Number of channels of the projected output.
         d_model: Working width of the transformer encoder.
         max_seq_len: Upper bound validated in ``__post_init__``. It is not consulted

--- a/graph_weather/models/aurora/processor.py
+++ b/graph_weather/models/aurora/processor.py
@@ -1,5 +1,6 @@
 """
-Perceiver Transformer Processor:
+Perceiver Transformer Processor
+
 - Takes encoded features and processes them using latent space mapping.
 - Uses a latent-space bottleneck to compress input dimensions.
 - Provides an efficient way to extract long-range dependencies.
@@ -15,6 +16,28 @@ import torch.nn as nn
 
 @dataclass
 class ProcessorConfig:
+    """
+    Architecture configuration for ``PerceiverProcessor``.
+
+    Attributes:
+        input_dim: Number of channels of the incoming features, matching the Swin3D output.
+        latent_dim: Number of channels of the projected output.
+        d_model: Working width of the transformer encoder.
+        max_seq_len: Maximum supported sequence length.
+        num_self_attention_layers: Number of transformer encoder layers.
+        num_cross_attention_layers: Number of cross-attention layers.
+        num_attention_heads: Number of attention heads per layer.
+        hidden_dropout: Dropout probability used inside the encoder layers.
+        attention_dropout: Dropout probability applied to the attention weights.
+        qk_head_dim: Optional per-head dimension of the query and key projections.
+        activation_fn: Name of the activation function used in the feed-forward blocks.
+        layer_norm_eps: Epsilon of the layer normalization.
+
+    Raises:
+        ValueError: If ``input_dim``, ``max_seq_len`` or ``num_attention_heads`` is not
+            positive, or if ``hidden_dropout`` or ``attention_dropout`` lies outside [0, 1].
+    """
+
     input_dim: int = 256  # Match Swin3D output
     latent_dim: int = 512
     d_model: int = 256  # Match input_dim for consistency
@@ -43,7 +66,22 @@ class ProcessorConfig:
 
 
 class PerceiverProcessor(nn.Module):
+    """
+    Process encoded features and pool them into a single latent vector per sample.
+
+    The input is projected to ``d_model``, passed through a stack of self-attention
+    transformer encoder layers, projected to ``latent_dim`` and finally averaged over the
+    sequence dimension.
+    """
+
     def __init__(self, config: Optional[ProcessorConfig] = None):
+        """
+        Initialize the processor.
+
+        Args:
+            config (Optional[ProcessorConfig]): Architecture configuration. A default
+                ``ProcessorConfig`` is used when ``None`` is given.
+        """
         super().__init__()
         self.config = config or ProcessorConfig()
 
@@ -66,6 +104,17 @@ class PerceiverProcessor(nn.Module):
         self.output_projection = nn.Linear(self.config.d_model, self.config.latent_dim)
 
     def forward(self, x, attention_mask=None):
+        """
+        Encode a batch of features and pool it into a latent representation.
+
+        Args:
+            x (torch.Tensor): Input features of shape (batch, seq_len, input_dim).
+            attention_mask (Optional[torch.Tensor]): Boolean mask of shape (batch, seq_len).
+                Positions that are ``False`` are masked out of the attention.
+
+        Returns:
+            torch.Tensor: Pooled latent representation of shape (batch, latent_dim).
+        """
         # Handle 4D input using einops for clearer reshaping
         if len(x.shape) == 4:
             # Rearrange from (batch, seq, height, width) to (batch, seq*height*width, features)

--- a/graph_weather/models/aurora/processor.py
+++ b/graph_weather/models/aurora/processor.py
@@ -23,15 +23,21 @@ class ProcessorConfig:
         input_dim: Number of channels of the incoming features, matching the Swin3D output.
         latent_dim: Number of channels of the projected output.
         d_model: Working width of the transformer encoder.
-        max_seq_len: Maximum supported sequence length.
+        max_seq_len: Upper bound validated in ``__post_init__``. It is not consulted
+            when the encoder is built.
         num_self_attention_layers: Number of transformer encoder layers.
-        num_cross_attention_layers: Number of cross-attention layers.
+        num_cross_attention_layers: Kept as part of the configuration. This
+            implementation has no cross-attention stack and never reads it.
         num_attention_heads: Number of attention heads per layer.
         hidden_dropout: Dropout probability used inside the encoder layers.
-        attention_dropout: Dropout probability applied to the attention weights.
-        qk_head_dim: Optional per-head dimension of the query and key projections.
+        attention_dropout: Validated in ``__post_init__`` but not applied. The
+            encoder layers use ``hidden_dropout`` for both attention and
+            feed-forward dropout.
+        qk_head_dim: Kept as part of the configuration; currently unused. The head
+            dimension follows from ``d_model`` and ``num_attention_heads``.
         activation_fn: Name of the activation function used in the feed-forward blocks.
-        layer_norm_eps: Epsilon of the layer normalization.
+        layer_norm_eps: Kept as part of the configuration; currently unused. The
+            encoder layers use the PyTorch default of 1e-5.
 
     Raises:
         ValueError: If ``input_dim``, ``max_seq_len`` or ``num_attention_heads`` is not

--- a/graph_weather/models/cafa/__init__.py
+++ b/graph_weather/models/cafa/__init__.py
@@ -1,5 +1,6 @@
 """
 CaFA (Climate-Aware Factorized Attention)'s Architectural Design:
+
 - Transformer-based weather forecast for computational efficiency
 - Uses Factorized Attention to reduce the cost of the attention mechanism
 - A Three-Part System for Efficient Forecasting: Encoder, Factorized Transformer, Decoder

--- a/graph_weather/models/cafa/decoder.py
+++ b/graph_weather/models/cafa/decoder.py
@@ -8,7 +8,7 @@ class CaFADecoder(nn.Module):
     """
     Decoder for CaFA.
 
-    After the Processor and FactorizedTransformer generated a prediction
+    After `CaFAProcessor` and its factorized transformer blocks generated a prediction
     in the latent space, the decoder's role is to translate this abstract
     representation back into a physical prediction.
     """

--- a/graph_weather/models/cafa/decoder.py
+++ b/graph_weather/models/cafa/decoder.py
@@ -1,20 +1,25 @@
+"""Decoder for the CaFA (Climate-Aware Factorized Attention) model."""
+
 import torch
 from torch import nn
 
 
 class CaFADecoder(nn.Module):
     """
-    Decoder for for CaFA
+    Decoder for CaFA.
+
     After the Processor and FactorizedTransformer generated a prediction
     in the latent space, the decoder's role is to translate this abstract
-    representation back into a physical prediction
+    representation back into a physical prediction.
     """
 
     def __init__(self, model_dim: int, output_channels: int, upsampling_factor: int = 1):
         """
+        Initialize the decoder.
+
         Args:
+            model_dim: Dimensions of the model's hidden layers (input channels)
             output_channels: No. of channels/features in output prediction
-            model_dim: Dimensions of the model's hidden layers (output channels)
             upsampling_factor: Factor to upsample the spatial dimensions.
                 Must match the downsampling factor in encoder.
         """
@@ -28,6 +33,8 @@ class CaFADecoder(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
+        Project the latent representation back to the physical output variables.
+
         Args:
             x: Input tensor of shape (batch, model_dim, height, width).
 

--- a/graph_weather/models/cafa/encoder.py
+++ b/graph_weather/models/cafa/encoder.py
@@ -1,21 +1,27 @@
+"""Encoder for the CaFA (Climate-Aware Factorized Attention) model."""
+
 import torch
 from torch import nn
 
 
 class CaFAEncoder(nn.Module):
     """
-    Encoder for CaFA
+    Encoder for CaFA.
+
     This projects complex, high-resolution input weather state
-    and transform it into a lower-resolution, high-dimensional
-    latent representation that the processor can work with
+    and transforms it into a lower-resolution, high-dimensional
+    latent representation that the processor can work with.
     """
 
     def __init__(self, input_channels: int, model_dim: int, downsampling_factor: int = 1):
         """
+        Initialize the encoder.
+
         Args:
-            input_channel: No. of channels/features in raw input data
+            input_channels: No. of channels/features in raw input data
             model_dim: Dimensions of the model's hidden layers (output channels)
-            downsampling_factor: Factor to downsample the spatial dimensions by (i.e., 2 means H/2, W/2)
+            downsampling_factor: Factor to downsample the spatial dimensions by
+                (i.e., 2 means H/2, W/2)
         """
         super().__init__()
         self.encoder = nn.Conv2d(
@@ -27,11 +33,14 @@ class CaFAEncoder(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
+        Project the input weather state into the latent representation.
+
         Args:
             x: Input tensor of shape (batch, channels, height, width)
 
         Returns:
-            Encoded tensor of shape (batch, model_dim, height/downsampling_factor, width/downsampling_factor)
+            Encoded tensor of shape
+            (batch, model_dim, height/downsampling_factor, width/downsampling_factor)
         """
         x = self.encoder(x)
         return x

--- a/graph_weather/models/cafa/factorize.py
+++ b/graph_weather/models/cafa/factorize.py
@@ -1,6 +1,7 @@
 """
-Core components for the Factorized Attention mechanism,
-based on the principles of Axial Attention.
+Core components for the Factorized Attention mechanism.
+
+Based on the principles of Axial Attention.
 """
 
 from einops import rearrange
@@ -10,7 +11,16 @@ from torch import einsum, nn
 def FeedFoward(dim, multiply=4, dropout=0.0):
     """
     Standard feed-forward block used in transformer architecture.
+
     Consists of 2 linear layers with GELU activation and dropouts, in between.
+
+    Args:
+        dim: Feature dimension of the input and of the output.
+        multiply: Multiplier for the hidden dimension of the inner linear layer.
+        dropout: Dropout probability applied after the activation and after the projection.
+
+    Returns:
+        An ``nn.Sequential`` module mapping features of size ``dim`` back to size ``dim``.
     """
     inner_dim = int(dim * multiply)
     return nn.Sequential(
@@ -25,10 +35,20 @@ def FeedFoward(dim, multiply=4, dropout=0.0):
 class AxialAttention(nn.Module):
     """
     Performs multi-head self-attention on a single axis of a 2D feature map.
+
     Core building block for Factorized Attention.
     """
 
     def __init__(self, dim, heads, dim_head=64, dropout=0.0):
+        """
+        Initialize the axial attention block.
+
+        Args:
+            dim: Feature dimension of the input and of the output.
+            heads: Number of attention heads.
+            dim_head: Feature dimension of each attention head.
+            dropout: Dropout probability applied to the attention weights.
+        """
         super().__init__()
         self.heads = heads
         self.scale = dim_head**-0.5
@@ -40,10 +60,17 @@ class AxialAttention(nn.Module):
 
     def forward(self, x, axis):
         """
-        Forward pass for axial attention
+        Forward pass for axial attention.
+
         Args:
             x: Input tensor of shape (batch, height, width, channels)
             axis: Axis to perform attention on (1 for height, 2 for width)
+
+        Returns:
+            Tensor of shape (batch, height, width, channels), the same shape as ``x``.
+
+        Raises:
+            ValueError: If ``axis`` is neither 1 nor 2.
         """
         b, h, w, d = x.shape
 
@@ -81,11 +108,21 @@ class AxialAttention(nn.Module):
 
 class FactorizedAttention(nn.Module):
     """
-    Combines 2 AxialAttention blocks to perform full factorized attention
-    over a 2D feature map, first along height then along width.
+    Combines 2 AxialAttention blocks to perform full factorized attention.
+
+    The blocks are applied over a 2D feature map, first along height then along width.
     """
 
     def __init__(self, dim, heads, dim_head=64, dropout=0.0):
+        """
+        Initialize the factorized attention block.
+
+        Args:
+            dim: Feature dimension of the input and of the output.
+            heads: Number of attention heads used by each axial attention block.
+            dim_head: Feature dimension of each attention head.
+            dropout: Dropout probability applied to the attention weights.
+        """
         super().__init__()
         self.attn_height = AxialAttention(dim, heads, dim_head, dropout)
         self.attn_width = AxialAttention(dim, heads, dim_head, dropout)
@@ -94,8 +131,15 @@ class FactorizedAttention(nn.Module):
 
     def forward(self, x):
         """
+        Attend along the height axis, then along the width axis.
+
+        Each axial attention block is applied with a pre-norm residual connection.
+
         Args:
             x: Input tensor of shape (batch, height, width, channels)
+
+        Returns:
+            Tensor of the same shape as ``x``.
         """
         x = x + self.attn_height(self.norm1(x), axis=1)
         x = x + self.attn_width(self.norm2(x), axis=2)
@@ -104,10 +148,23 @@ class FactorizedAttention(nn.Module):
 
 class FactorizedTransformerBlock(nn.Module):
     """
-    Standalone transformer block using Factorized attention
+    Standalone transformer block using Factorized attention.
+
+    Pairs a factorized attention sub-layer with a feed-forward sub-layer, each
+    applied with a pre-norm residual connection.
     """
 
     def __init__(self, dim, heads, dim_head=64, feedforward_multiplier=4, dropout=0.0):
+        """
+        Initialize the factorized transformer block.
+
+        Args:
+            dim: Feature dimension of the input and of the output.
+            heads: Number of attention heads used by each axial attention block.
+            dim_head: Feature dimension of each attention head.
+            feedforward_multiplier: Multiplier for the hidden dimension of the feed-forward block.
+            dropout: Dropout probability used by the attention and feed-forward blocks.
+        """
         super().__init__()
         self.attn = FactorizedAttention(dim, heads, dim_head, dropout)
         self.ffn = FeedFoward(dim, feedforward_multiplier, dropout)
@@ -116,8 +173,13 @@ class FactorizedTransformerBlock(nn.Module):
 
     def forward(self, x):
         """
+        Apply factorized attention and the feed-forward block, both with residuals.
+
         Args:
             x: Input tensor of shape (batch, height, width, channels)
+
+        Returns:
+            Tensor of the same shape as ``x``.
         """
         x = x + self.attn(self.norm1(x))
         x = x + self.ffn(self.norm2(x))

--- a/graph_weather/models/cafa/model.py
+++ b/graph_weather/models/cafa/model.py
@@ -1,3 +1,5 @@
+"""End-to-end CaFA (Climate-Aware Factorized Attention) forecaster."""
+
 import torch
 import torch.nn.functional as F
 from torch import nn
@@ -9,8 +11,9 @@ from .processor import CaFAProcessor
 
 class CaFAForecaster(nn.Module):
     """
-    CaFA (Climate-Aware Factorized Attention) model
-    Puts together Encoder, Processor and Decoder into an end-to-end model
+    CaFA (Climate-Aware Factorized Attention) model.
+
+    Puts together Encoder, Processor and Decoder into an end-to-end model.
     """
 
     def __init__(
@@ -26,6 +29,8 @@ class CaFAForecaster(nn.Module):
         dropout: float = 0.0,
     ):
         """
+        Initialize the forecaster.
+
         Args:
             input_channels: No. of input channels/features
             output_channels: No. of channels to predict
@@ -64,6 +69,11 @@ class CaFAForecaster(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
+        Encode, process and decode one input state, restoring the input grid size.
+
+        Odd-sized inputs are zero-padded to a multiple of the downsampling factor
+        and the padding is cropped off again before the output is returned.
+
         Args:
             x: Input tensor of shape (batch, input_channels, height, width)
 

--- a/graph_weather/models/cafa/processor.py
+++ b/graph_weather/models/cafa/processor.py
@@ -1,3 +1,5 @@
+"""Processor for the CaFA (Climate-Aware Factorized Attention) model."""
+
 import torch
 import torch.nn as nn
 from einops import rearrange
@@ -7,7 +9,8 @@ from .factorize import FactorizedTransformerBlock
 
 class CaFAProcessor(nn.Module):
     """
-    Processor module for CaFA
+    Processor module for CaFA.
+
     Handles latent feature map through multiple layers of self-attention,
     allowing information to propagate across the entire global grid.
     """
@@ -22,6 +25,8 @@ class CaFAProcessor(nn.Module):
         dropout: float = 0.0,
     ):
         """
+        Initialize the processor.
+
         Args:
             dim: No. of input channels/ features
             depth: No. of FactorizedTransformerBlocks to stack
@@ -40,8 +45,12 @@ class CaFAProcessor(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """
+        Run the latent feature map through the stack of transformer blocks.
+
+        The channel axis is moved last for the blocks and restored on the way out.
+
         Args:
-            x: Input tensor of shape (batch, height, width, channels)
+            x: Input tensor of shape (batch, channels, height, width)
 
         Returns:
             Refined tensor of same shape

--- a/graph_weather/models/fengwu_ghr/layers.py
+++ b/graph_weather/models/fengwu_ghr/layers.py
@@ -4,7 +4,8 @@ This module gathers the layers used to run a vision-transformer backbone over we
 interpolation between an irregular set of lat/lon points and a regular grid, fixed sine-cosine
 positional embeddings, the attention and feed-forward blocks, the `ImageMetaModel` backbone and
 its lat/lon counterpart `MetaModel`, the wrappers that run either of them at a higher
-resolution by splitting the input into sub-images, and LoRA layers for fine-tuning.
+resolution by splitting the input into interleaved sub-images, and LoRA layers for
+fine-tuning.
 """
 
 import torch
@@ -411,7 +412,9 @@ class WrapperImageModel(nn.Module):
     """
     Run an `ImageMetaModel` on an image `scale_factor` times larger than its own.
 
-    The image is cut into `s_h * s_w` sub-images that are stacked along the batch dimension, a
+    The image is split into `s_h * s_w` interleaved sub-images, each taking every `s_h`-th row
+    and every `s_w`-th column rather than a contiguous tile, which are stacked along the
+    batch dimension, a
     copy of the given model built with `res=True` is applied to them, and the sub-images are
     then put back together. The weights of the given model are loaded into that copy.
     """
@@ -438,7 +441,7 @@ class WrapperImageModel(nn.Module):
 
     def forward(self, x):
         """
-        Split the image into sub-images, run the wrapped model and reassemble them.
+        Split the image into interleaved sub-images, run the wrapped model and reassemble.
 
         Args:
             x: Input tensor of shape `(batch, channels, height * s_h, width * s_w)`.
@@ -627,7 +630,13 @@ class LoRALayer(nn.Module):
 
 
 class LoRAModule(nn.Module):
-    """Model whose linear layers are replaced by `LoRALayer` and set to evaluation mode."""
+    """
+    Wrap a model, put it in evaluation mode and attach `LoRALayer` for its linear layers.
+
+    The wrapping uses `setattr(model, name, ...)` with the dotted names returned by
+    `named_modules`, so only linear layers that are direct attributes of `model` are
+    substituted; nested ones gain a sibling attribute and keep running unchanged.
+    """
 
     def __init__(self, model, r=4):
         """

--- a/graph_weather/models/fengwu_ghr/layers.py
+++ b/graph_weather/models/fengwu_ghr/layers.py
@@ -1,3 +1,12 @@
+"""Building blocks for the FengWu-GHR model.
+
+This module gathers the layers used to run a vision-transformer backbone over weather data:
+interpolation between an irregular set of lat/lon points and a regular grid, fixed sine-cosine
+positional embeddings, the attention and feed-forward blocks, the `ImageMetaModel` backbone and
+its lat/lon counterpart `MetaModel`, the wrappers that run either of them at a higher
+resolution by splitting the input into sub-images, and LoRA layers for fine-tuning.
+"""
+
 import torch
 from einops import rearrange
 from einops.layers.torch import Rearrange
@@ -7,12 +16,37 @@ from torch_geometric.utils import scatter
 
 
 def pair(t):
+    """
+    Return `t` as a two-element tuple.
+
+    Args:
+        t: A tuple, which is returned unchanged, or any other value, which is duplicated.
+
+    Returns:
+        `t` itself if it is already a tuple, otherwise `(t, t)`.
+    """
     return t if isinstance(t, tuple) else (t, t)
 
 
 def knn_interpolate(
     x: torch.Tensor, pos_x: torch.Tensor, pos_y: torch.Tensor, k: int = 4, num_workers: int = 1
 ):
+    """
+    Interpolate features from one set of positions onto another.
+
+    Every target position takes the weighted mean of the features of its `k` nearest source
+    positions, weighted by the inverse of the squared distance between them.
+
+    Args:
+        x: Features of the source nodes, of shape `(num_source_nodes, num_features)`.
+        pos_x: Coordinates of the source nodes, of shape `(num_source_nodes, num_dims)`.
+        pos_y: Coordinates of the target nodes, of shape `(num_target_nodes, num_dims)`.
+        k: Number of nearest source nodes used for each target node.
+        num_workers: Number of workers used by the k-nearest-neighbor search.
+
+    Returns:
+        The interpolated features, of shape `(num_target_nodes, num_features)`.
+    """
     with torch.no_grad():
         assign_index = knn(pos_x, pos_y, k, num_workers=num_workers)
         y_idx, x_idx = assign_index[0], assign_index[1]
@@ -32,6 +66,22 @@ def knn_interpolate(
 
 
 def posemb_sincos_2d(h, w, dim, temperature: int = 10000, dtype=torch.float32):
+    """
+    Build a fixed two-dimensional sine-cosine positional embedding.
+
+    Args:
+        h: Number of positions along the height of the grid.
+        w: Number of positions along the width of the grid.
+        dim: Size of the embedding. Must be a multiple of 4.
+        temperature: Base of the geometric progression used for the frequencies.
+        dtype: Data type of the returned embedding.
+
+    Returns:
+        The positional embedding, of shape `(h * w, dim)`.
+
+    Raises:
+        AssertionError: If `dim` is not a multiple of 4.
+    """
     y, x = torch.meshgrid(torch.arange(h), torch.arange(w), indexing="ij")
     assert (dim % 4) == 0, "feature dimension must be multiple of 4 for sincos emb"
     omega = torch.arange(dim // 4) / (dim // 4 - 1)
@@ -47,7 +97,16 @@ def posemb_sincos_2d(h, w, dim, temperature: int = 10000, dtype=torch.float32):
 
 
 class FeedForward(nn.Module):
+    """Pre-norm position-wise feed-forward block."""
+
     def __init__(self, dim, hidden_dim):
+        """
+        Initialize FeedForward.
+
+        Args:
+            dim: Size of the input and of the output features.
+            hidden_dim: Size of the hidden layer.
+        """
         super().__init__()
         self.net = nn.Sequential(
             nn.LayerNorm(dim),
@@ -57,11 +116,30 @@ class FeedForward(nn.Module):
         )
 
     def forward(self, x):
+        """
+        Apply the feed-forward network.
+
+        Args:
+            x: Input tensor whose last dimension is `dim`.
+
+        Returns:
+            A tensor with the same shape as `x`.
+        """
         return self.net(x)
 
 
 class Attention(nn.Module):
+    """Pre-norm multi-head self-attention block."""
+
     def __init__(self, dim, heads=8, dim_head=64):
+        """
+        Initialize Attention.
+
+        Args:
+            dim: Size of the input and of the output features.
+            heads: Number of attention heads.
+            dim_head: Size of each attention head.
+        """
         super().__init__()
         inner_dim = dim_head * heads
         self.heads = heads
@@ -74,6 +152,15 @@ class Attention(nn.Module):
         self.to_out = nn.Linear(inner_dim, dim, bias=False)
 
     def forward(self, x):
+        """
+        Apply multi-head self-attention along the sequence dimension.
+
+        Args:
+            x: Input tensor of shape `(batch, sequence, dim)`.
+
+        Returns:
+            A tensor with the same shape as `x`.
+        """
         x = self.norm(x)
 
         qkv = self.to_qkv(x).chunk(3, dim=-1)
@@ -89,9 +176,36 @@ class Attention(nn.Module):
 
 
 class Transformer(nn.Module):
+    """
+    Stack of residual attention and feed-forward blocks, followed by a layer norm.
+
+    When `res` is True the batch is assumed to hold the `s_h * s_w` sub-images of a single
+    image, and each block is followed by an extra attention layer applied across those
+    sub-images: the sequence is regrouped so that attention runs over the `s_h * s_w` axis for
+    each patch position, and is then restored to its original layout.
+    """
+
     def __init__(
         self, dim, depth, heads, dim_head, mlp_dim, res=False, image_size=None, scale_factor=None
     ):
+        """
+        Initialize Transformer.
+
+        Args:
+            dim: Size of the input and of the output features.
+            depth: Number of attention and feed-forward blocks.
+            heads: Number of attention heads.
+            dim_head: Size of each attention head.
+            mlp_dim: Size of the hidden layer of the feed-forward blocks.
+            res: Whether to add the extra attention layers acting across sub-images.
+            image_size: Size `(h, w)` in patches of one sub-image, or a single int if it is
+                square. Only used when `res` is True.
+            scale_factor: Number `(s_h, s_w)` of sub-images along each axis, or a single int
+                for the same value on both axes. Only used when `res` is True.
+
+        Raises:
+            AssertionError: If `res` is True and `image_size` or `scale_factor` is None.
+        """
         super().__init__()
         self.depth = depth
         self.res = res
@@ -136,6 +250,15 @@ class Transformer(nn.Module):
                 )
 
     def forward(self, x):
+        """
+        Run every block over the input sequence.
+
+        Args:
+            x: Input tensor of shape `(batch, sequence, dim)`.
+
+        Returns:
+            The normalized output tensor, of the same shape as `x`.
+        """
         for i in range(self.depth):
             attn, ff = self.layers[i]
             x = attn(x) + x
@@ -149,6 +272,15 @@ class Transformer(nn.Module):
 
 
 class ImageMetaModel(nn.Module):
+    """
+    Vision-transformer backbone mapping an image to an image of the same shape.
+
+    The input is cut into non-overlapping patches, each patch is embedded, a fixed sine-cosine
+    positional embedding is added, a `Transformer` is applied and the patches are folded back
+    into an image. The embedding size is the flattened size of one patch, so the number of
+    channels is preserved.
+    """
+
     def __init__(
         self,
         *,
@@ -163,6 +295,27 @@ class ImageMetaModel(nn.Module):
         scale_factor=None,
         **kwargs,
     ):
+        """
+        Initialize ImageMetaModel.
+
+        Args:
+            image_size: Size `(height, width)` of the image, or a single int if it is square.
+            patch_size: Size `(height, width)` of a patch, or a single int if it is square.
+            depth: Number of transformer blocks.
+            heads: Number of attention heads.
+            mlp_dim: Size of the hidden layer of the feed-forward blocks.
+            channels: Number of channels of the image.
+            dim_head: Size of each attention head.
+            res: Whether the transformer gets the extra attention layers across sub-images.
+            scale_factor: Number `(s_h, s_w)` of sub-images along each axis, or a single int
+                for the same value on both axes.
+            **kwargs: Ignored. Lets the attributes of an existing `ImageMetaModel` be passed
+                straight through when a rescaled copy of it is built.
+
+        Raises:
+            AssertionError: If `res` is True while `scale_factor` is None, or if the image size
+                is not divisible by the patch size.
+        """
         super().__init__()
         # TODO this can probably be done better
         self.image_size = image_size
@@ -229,6 +382,18 @@ class ImageMetaModel(nn.Module):
         )
 
     def forward(self, x):
+        """
+        Embed the image into patches, run the transformer and rebuild the image.
+
+        Args:
+            x: Input tensor of shape `(batch, channels, height, width)`.
+
+        Returns:
+            A tensor with the same shape as `x`.
+
+        Raises:
+            AssertionError: If `x` does not have `channels` channels.
+        """
         assert x.shape[1] == self.channels, "Wrong number of channels"
         device = x.device
         dtype = x.dtype
@@ -243,7 +408,23 @@ class ImageMetaModel(nn.Module):
 
 
 class WrapperImageModel(nn.Module):
+    """
+    Run an `ImageMetaModel` on an image `scale_factor` times larger than its own.
+
+    The image is cut into `s_h * s_w` sub-images that are stacked along the batch dimension, a
+    copy of the given model built with `res=True` is applied to them, and the sub-images are
+    then put back together. The weights of the given model are loaded into that copy.
+    """
+
     def __init__(self, image_meta_model: ImageMetaModel, scale_factor):
+        """
+        Initialize WrapperImageModel.
+
+        Args:
+            image_meta_model: Model whose settings and weights are reused by the `res=True` copy.
+            scale_factor: Number `(s_h, s_w)` of sub-images along each axis, or a single int
+                for the same value on both axes.
+        """
         super().__init__()
         s_h, s_w = pair(scale_factor)
         self.batcher = Rearrange("b c (h s_h) (w s_w) -> (b s_h s_w) c h w", s_h=s_h, s_w=s_w)
@@ -256,6 +437,15 @@ class WrapperImageModel(nn.Module):
         self.debatcher = Rearrange("(b s_h s_w) c h w -> b c (h s_h) (w s_w)", s_h=s_h, s_w=s_w)
 
     def forward(self, x):
+        """
+        Split the image into sub-images, run the wrapped model and reassemble them.
+
+        Args:
+            x: Input tensor of shape `(batch, channels, height * s_h, width * s_w)`.
+
+        Returns:
+            A tensor with the same shape as `x`.
+        """
         x = self.batcher(x)
         x = self.image_meta_model(x)
         x = self.debatcher(x)
@@ -263,6 +453,13 @@ class WrapperImageModel(nn.Module):
 
 
 class MetaModel(nn.Module):
+    """
+    Apply an `ImageMetaModel` to data defined on an irregular set of lat/lon points.
+
+    The point values are interpolated onto a regular lat/lon grid, the image backbone is run on
+    that grid, and the output is interpolated back onto the original points.
+    """
+
     def __init__(
         self,
         lat_lons: list,
@@ -275,6 +472,19 @@ class MetaModel(nn.Module):
         channels,
         dim_head=64,
     ):
+        """
+        Initialize MetaModel.
+
+        Args:
+            lat_lons: List of `(lat, lon)` coordinates of the input points.
+            image_size: Size `(height, width)` of the grid, or a single int if it is square.
+            patch_size: Size `(height, width)` of a patch, or a single int if it is square.
+            depth: Number of transformer blocks.
+            heads: Number of attention heads.
+            mlp_dim: Size of the hidden layer of the feed-forward blocks.
+            channels: Number of channels of the gridded data.
+            dim_head: Size of each attention head.
+        """
         super().__init__()
         self.i_h, self.i_w = pair(image_size)
 
@@ -295,6 +505,15 @@ class MetaModel(nn.Module):
         )
 
     def forward(self, x):
+        """
+        Interpolate onto the grid, run the image model and interpolate back to the points.
+
+        Args:
+            x: Input tensor of shape `(batch, num_points, channels)`.
+
+        Returns:
+            A tensor with the same shape as `x`.
+        """
         b, n, c = x.shape
 
         x = rearrange(x, "b n c -> n (b c)")
@@ -309,7 +528,25 @@ class MetaModel(nn.Module):
 
 
 class WrapperMetaModel(nn.Module):
+    """
+    Run a `MetaModel` on a lat/lon grid `scale_factor` times finer than its own.
+
+    The points are interpolated onto the finer grid, that grid is cut into `s_h * s_w`
+    sub-images, a copy of the wrapped image backbone built with `res=True` is applied to them,
+    and the result is reassembled and interpolated back onto the original points.
+    """
+
     def __init__(self, lat_lons: list, meta_model: MetaModel, scale_factor):
+        """
+        Initialize WrapperMetaModel.
+
+        Args:
+            lat_lons: List of `(lat, lon)` coordinates of the input points.
+            meta_model: Model whose grid size is scaled up and whose image backbone settings
+                and weights are reused by the `res=True` copy.
+            scale_factor: Number `(s_h, s_w)` of sub-images along each axis, or a single int
+                for the same value on both axes.
+        """
         super().__init__()
         s_h, s_w = pair(scale_factor)
         self.i_h, self.i_w = meta_model.i_h * s_h, meta_model.i_w * s_w
@@ -331,6 +568,15 @@ class WrapperMetaModel(nn.Module):
         self.debatcher = Rearrange("(b s_h s_w) c h w -> b c (h s_h) (w s_w)", s_h=s_h, s_w=s_w)
 
     def forward(self, x):
+        """
+        Interpolate onto the finer grid, run the wrapped image model and interpolate back.
+
+        Args:
+            x: Input tensor of shape `(batch, num_points, channels)`.
+
+        Returns:
+            A tensor with the same shape as `x`.
+        """
         b, n, c = x.shape
 
         x = rearrange(x, "b n c -> n (b c)")
@@ -349,6 +595,8 @@ class WrapperMetaModel(nn.Module):
 
 
 class LoRALayer(nn.Module):
+    """Linear layer with an added low-rank term of rank `r`."""
+
     def __init__(self, linear_layer: nn.Module, r: int):
         """
         Initialize LoRALayer.
@@ -365,11 +613,22 @@ class LoRALayer(nn.Module):
         self.linear_layer = linear_layer
 
     def forward(self, x):
+        """
+        Add the low-rank term to the output of the wrapped linear layer.
+
+        Args:
+            x: Input tensor.
+
+        Returns:
+            The sum of the linear layer output and of the low-rank term.
+        """
         out = self.linear_layer(x) + self.B @ self.A @ x
         return out
 
 
 class LoRAModule(nn.Module):
+    """Model whose linear layers are replaced by `LoRALayer` and set to evaluation mode."""
+
     def __init__(self, model, r=4):
         """
         Initialize LoRAModule.
@@ -387,4 +646,13 @@ class LoRAModule(nn.Module):
         self.model = model
 
     def forward(self, x):
+        """
+        Run the wrapped model.
+
+        Args:
+            x: Input tensor.
+
+        Returns:
+            The output of the wrapped model.
+        """
         return self.model(x)

--- a/graph_weather/models/fengwu_ghr/layers.py
+++ b/graph_weather/models/fengwu_ghr/layers.py
@@ -73,7 +73,9 @@ def posemb_sincos_2d(h, w, dim, temperature: int = 10000, dtype=torch.float32):
     Args:
         h: Number of positions along the height of the grid.
         w: Number of positions along the width of the grid.
-        dim: Size of the embedding. Must be a multiple of 4.
+        dim: Size of the embedding. Must be a multiple of 4, and at least 8: the
+            assertion admits `dim == 4`, but then `dim // 4 - 1` is zero and the
+            frequencies are not finite.
         temperature: Base of the geometric progression used for the frequencies.
         dtype: Data type of the returned embedding.
 

--- a/graph_weather/models/fgn/__init__.py
+++ b/graph_weather/models/fgn/__init__.py
@@ -1,1 +1,6 @@
+"""Functional Generative Network (FGN) model.
+
+Exposes ``FunctionalGenerativeNetwork``, the FGN weather model.
+"""
+
 from graph_weather.models.fgn.model import FunctionalGenerativeNetwork

--- a/graph_weather/models/fgn/layers/__init__.py
+++ b/graph_weather/models/fgn/layers/__init__.py
@@ -1,0 +1,1 @@
+"""Layers used to build the Functional Generative Network (FGN) model."""

--- a/graph_weather/models/graphcast/model.py
+++ b/graph_weather/models/graphcast/model.py
@@ -125,7 +125,8 @@ class GraphCast(torch.nn.Module):
         Disables all other hierarchical checkpointing when enabled.
 
         Args:
-            checkpoint_flag: If True, checkpoint entire model. If False, use hierarchical checkpointing.
+            checkpoint_flag: If True, checkpoint entire model. If False, use
+                hierarchical checkpointing.
         """
         self._checkpoint_model = checkpoint_flag
         if checkpoint_flag:

--- a/graph_weather/models/layers/assimilator_decoder.py
+++ b/graph_weather/models/layers/assimilator_decoder.py
@@ -61,6 +61,9 @@ class AssimilatorDecoder(torch.nn.Module):
             mlp_norm_type: Type of norm for the MLPs
                 one of 'LayerNorm', 'GraphNorm', 'InstanceNorm', 'BatchNorm', 'MessageNorm', or None
             use_checkpointing: Whether to use gradient checkpointing to reduce model size
+            efficient_batching: Whether to decode each batch element separately against the
+                single shared graph instead of replicating that graph and its edge
+                attributes batch_size times, which uses less memory
         """
         super().__init__()
         self.use_checkpointing = use_checkpointing

--- a/graph_weather/models/layers/constraint_layer.py
+++ b/graph_weather/models/layers/constraint_layer.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 
 class PhysicalConstraintLayer(nn.Module):
-    """
+    """Apply a physical constraint to a network's high-resolution output.
 
     This module implements several constraint types on the network’s intermediate outputs ỹ,
     given the corresponding low-resolution input x. The following equations are implemented
@@ -98,7 +98,8 @@ class PhysicalConstraintLayer(nn.Module):
         return self.model.grid_to_graph(result)
 
     def additive_constraint(self, hr, lr):
-        """Enforces local conservation using an additive correction:
+        """Enforces local conservation using an additive correction.
+
         y = ỹ + ( x - avg(ỹ) )
         where avg(ỹ) is computed per patch (via an average-pooling layer).
 

--- a/graph_weather/models/layers/encoder.py
+++ b/graph_weather/models/layers/encoder.py
@@ -67,6 +67,9 @@ class Encoder(torch.nn.Module):
             mlp_norm_type: Type of norm for the MLPs
                 one of 'LayerNorm', 'GraphNorm', 'InstanceNorm', 'BatchNorm', 'MessageNorm', or None
             use_checkpointing: Whether to use gradient checkpointing to use less memory
+            efficient_batching: Whether to encode each batch element separately against the
+                single shared graph instead of replicating that graph and its edge
+                attributes batch_size times, which uses less memory
         """
         super().__init__()
         self.use_checkpointing = use_checkpointing
@@ -208,7 +211,8 @@ class Encoder(torch.nn.Module):
             )  # Update attributes based on distance
             # Copy attributes batch times
             edge_attr = einops.repeat(edge_attr, "e f -> (repeat e) f", repeat=batch_size)
-            # Expand edge index correct number of times while adding the proper number to the edge index
+            # Expand edge index correct number of times while adding the proper
+            # number to the edge index
             edge_index = torch.cat(
                 [
                     self.graph.edge_index + i * torch.max(self.graph.edge_index) + i

--- a/graph_weather/models/layers/film.py
+++ b/graph_weather/models/layers/film.py
@@ -1,3 +1,5 @@
+"""FiLM (Feature-wise Linear Modulation) layers conditioned on a lead-time index."""
+
 import torch
 import torch.nn as nn
 
@@ -16,6 +18,14 @@ class FiLMGenerator(nn.Module):
     """
 
     def __init__(self, num_lead_times: int, hidden_dim: int, feature_dim: int):
+        """Build the MLP that maps a one-hot lead time to FiLM parameters.
+
+        Args:
+            num_lead_times (int): Number of possible lead-time categories, which is also
+                the size of the one-hot input vector.
+            hidden_dim (int): Hidden size of the internal MLP.
+            feature_dim (int): Output dimensionality of each of gamma and beta.
+        """
         super().__init__()
         self.num_lead_times = num_lead_times
         self.feature_dim = feature_dim

--- a/graph_weather/models/layers/grid_to_points.py
+++ b/graph_weather/models/layers/grid_to_points.py
@@ -1,0 +1,5 @@
+"""Placeholder module for a grid-to-points layer.
+
+This module is intended to hold the layer that maps values defined on a regular
+lat/lon grid onto arbitrary lat/lon points. No implementation is provided yet.
+"""

--- a/graph_weather/models/layers/points_to_grid.py
+++ b/graph_weather/models/layers/points_to_grid.py
@@ -1,3 +1,5 @@
-"""
-This is designed to abstract away the lat/lon points and as a layer that can be put in front of models that more expecta regular lat/lon grid as input.
+"""Placeholder module for a points-to-grid layer.
+
+This is designed to abstract away the lat/lon points and act as a layer that can be
+put in front of models that expect a regular lat/lon grid as input.
 """

--- a/graph_weather/models/layers/processor.py
+++ b/graph_weather/models/layers/processor.py
@@ -74,7 +74,8 @@ class Processor(torch.nn.Module):
 
         Args:
             checkpoint_segments: Number of checkpointing segments for gradient computation.
-                - 0: Use processor's internal per-block checkpointing (controlled by use_checkpointing)
+                - 0: Use processor's internal per-block checkpointing (controlled
+                  by use_checkpointing)
                 - -1: Checkpoint entire processor as one segment (handled at GraphCast level)
                 - N > 0: Checkpoint every N blocks (not yet implemented)
         """

--- a/graph_weather/models/losses.py
+++ b/graph_weather/models/losses.py
@@ -62,7 +62,8 @@ class NormalizedMSELoss(torch.nn.Module):
             device: checks for device whether it supports gpu or not
             normalize: option for normalize
         """
-        # TODO Rescale by nominal static air density at each pressure level, could be 1/pressure level or something similar
+        # TODO Rescale by nominal static air density at each pressure level, could be
+        # 1/pressure level or something similar
         super().__init__()
         self.feature_variance = torch.tensor(feature_variance)
         assert not torch.isnan(self.feature_variance).any()
@@ -140,15 +141,33 @@ class AMSENormalizedLoss(nn.Module):
     2. Decorrelation Error (phase misalignment/coherence loss).
 
     This implementation follows the formulation in:
-    "Fixing the Double Penalty in Data-Driven Weather Forecasting Through a Modified Spherical Harmonic Loss Function"
+    "Fixing the Double Penalty in Data-Driven Weather Forecasting Through a Modified
+    Spherical Harmonic Loss Function"
     (ICML 2025 Poster).
 
     Args:
-        feature_variance (list or torch.Tensor): Variance of each physical feature for normalization (length C).
+        feature_variance (list or torch.Tensor): Variance of each physical feature, used to
+            normalize the per-feature spectral loss (length C).
         epsilon (float): Small constant for numerical stability.
     """
 
     def __init__(self, feature_variance: list | torch.Tensor, epsilon: float = 1e-9):
+        """
+        Initialize the AMSE loss.
+
+        The feature variances are stored as a float32 buffer so that they follow the module
+        across devices. The spherical harmonic transforms themselves are not built here; they
+        are created lazily and cached per ``(nlat, nlon, device)`` by ``_get_sht``.
+
+        Args:
+            feature_variance (list or torch.Tensor): Variance of each physical feature, used
+                to normalize the per-feature spectral loss (length C). A non-tensor input is
+                converted with ``torch.tensor``; a tensor input is cloned, detached and cast
+                to float32, so the tensor passed in by the caller is left untouched.
+            epsilon (float): Small constant for numerical stability. It is added to the power
+                spectral densities before the square root in the amplitude term, to the
+                coherence denominator, and to the feature variance used for normalization.
+        """
         super().__init__()
         if not isinstance(feature_variance, torch.Tensor):
             feature_variance = torch.tensor(feature_variance, dtype=torch.float32)
@@ -157,14 +176,26 @@ class AMSENormalizedLoss(nn.Module):
 
         self.register_buffer("feature_variance", feature_variance)
 
-        # SHT cache to avoid re-initializing on every forward pass since object performs some expensive pre-computation when it's initialized. Doing this repeatedly inside the training loop can add unnecessary overhead.
+        # SHT cache to avoid re-initializing on every forward pass since object performs
+        # some expensive pre-computation when it's initialized. Doing this repeatedly
+        # inside the training loop can add unnecessary overhead.
         self.epsilon = epsilon
         self.sht_cache = {}
 
     def _get_sht(self, nlat: int, nlon: int, device: torch.device) -> th.RealSHT:
         """
         Helper to get a cached SHT object, creating it if it doesn't exist.
+
         This prevents re-initializing the SHT object on every forward pass.
+
+        Args:
+            nlat (int): Number of latitude points of the grid.
+            nlon (int): Number of longitude points of the grid.
+            device (torch.device): Device the transform is moved to. It is part of the cache
+                key, so each device keeps its own instance.
+
+        Returns:
+            th.RealSHT: Transform for an ``equiangular`` grid of shape ``(nlat, nlon)``.
         """
         key = (nlat, nlon, device)
         if key not in self.sht_cache:

--- a/graph_weather/models/weathermesh/__init__.py
+++ b/graph_weather/models/weathermesh/__init__.py
@@ -1,0 +1,7 @@
+"""
+WeatherMesh model components.
+
+Holds the encoder, neighborhood attention processor and decoder modules that make
+up the WeatherMesh implementation, together with the dataclass configs used to
+build them from plain dictionaries.
+"""

--- a/graph_weather/models/weathermesh/decoder.py
+++ b/graph_weather/models/weathermesh/decoder.py
@@ -15,6 +15,21 @@ from graph_weather.models.weathermesh.layers import ConvUpBlock
 
 @dataclass
 class WeatherMeshDecoderConfig:
+    """
+    Configuration for `WeatherMeshDecoder`.
+
+    Attributes:
+        latent_dim: Channel width of the latent volume fed to the decoder.
+        output_channels_2d: Number of channels of the reconstructed surface field.
+        output_channels_3d: Number of channels of the reconstructed pressure level field.
+        n_conv_blocks: Number of `ConvUpBlock` stages in each of the two paths.
+        hidden_dim: Base channel width. The latent is first widened to
+            ``hidden_dim * 2 ** n_conv_blocks`` channels.
+        kernel_size: Neighborhood attention window as ``(depth, height, width)``.
+        num_heads: Number of attention heads per neighborhood attention layer.
+        num_transformer_layers: Number of neighborhood attention layers applied to the latent.
+    """
+
     latent_dim: int
     output_channels_2d: int
     output_channels_3d: int
@@ -26,13 +41,37 @@ class WeatherMeshDecoderConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMeshDecoder":
+        """
+        Build the decoder configuration from a plain dictionary.
+
+        Args:
+            json: Mapping whose keys match the fields of this dataclass.
+
+        Returns:
+            The `WeatherMeshDecoderConfig` deserialized by dacite.
+        """
         return dacite.from_dict(data_class=WeatherMeshDecoderConfig, data=json)
 
     def to_json(self) -> dict:
+        """
+        Convert the configuration into a plain dictionary.
+
+        Returns:
+            A dictionary with one entry per dataclass field.
+        """
         return dacite.asdict(self)
 
 
 class WeatherMeshDecoder(nn.Module):
+    """
+    Decoder that turns a latent volume back into surface and pressure level fields.
+
+    The latent is first refined by a stack of 3D neighborhood attention layers and widened by
+    a 1x1x1 convolution. It is then split along the depth axis: every level but the last feeds
+    the 3D upsampling path, and the last level is squeezed to 2D and feeds the surface path.
+    Both paths are stacks of `ConvUpBlock` layers that reverse the encoder downsampling.
+    """
+
     def __init__(
         self,
         latent_dim,
@@ -44,6 +83,21 @@ class WeatherMeshDecoder(nn.Module):
         num_heads: int = 8,
         num_transformer_layers: int = 3,
     ):
+        """
+        Build the latent attention stack, the split projection and the two upsampling paths.
+
+        Args:
+            latent_dim: Channel width of the latent volume fed to the decoder.
+            output_channels_2d: Number of channels of the reconstructed surface field.
+            output_channels_3d: Number of channels of the reconstructed pressure level field.
+            n_conv_blocks: Number of `ConvUpBlock` stages in each of the two paths.
+            hidden_dim: Base channel width. The latent is widened to
+                ``hidden_dim * 2 ** n_conv_blocks`` channels before the upsampling paths.
+            kernel_size: Neighborhood attention window as ``(depth, height, width)``.
+            num_heads: Number of attention heads per neighborhood attention layer.
+            num_transformer_layers: Number of neighborhood attention layers applied to the
+                latent.
+        """
         super().__init__()
 
         # Transformer layers for initial decoding
@@ -83,6 +137,19 @@ class WeatherMeshDecoder(nn.Module):
         )
 
     def forward(self, latent: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Decode a latent volume into a surface field and a pressure level field.
+
+        Args:
+            latent: Latent tensor of shape ``(B, D, H, W, latent_dim)`` with depth ``D``
+                covering the pressure levels plus one trailing surface level.
+
+        Returns:
+            A tuple ``(surface, pressure)``. ``surface`` has shape
+            ``(B, output_channels_2d, H', W')`` and ``pressure`` has shape
+            ``(B, output_channels_3d, D - 1, H', W')``, where ``H'`` and ``W'`` are the
+            horizontal sizes after ``n_conv_blocks`` upsampling stages.
+        """
         # Needs to be (B,D,H,W,C) with Batch, Depth (vertical levels), Height, Width, Channels
         # Apply transformer layers
         for transformer in self.transformer_layers:

--- a/graph_weather/models/weathermesh/decoder.py
+++ b/graph_weather/models/weathermesh/decoder.py
@@ -58,6 +58,11 @@ class WeatherMeshDecoderConfig:
 
         Returns:
             A dictionary with one entry per dataclass field.
+
+        Note:
+            ``dacite`` does not provide ``asdict``, so this currently raises
+            ``AttributeError``. Flagged in the pull request that added this
+            docstring; the change itself touches docstrings only.
         """
         return dacite.asdict(self)
 

--- a/graph_weather/models/weathermesh/encoder.py
+++ b/graph_weather/models/weathermesh/encoder.py
@@ -15,6 +15,24 @@ from graph_weather.models.weathermesh.layers import ConvDownBlock
 
 @dataclass
 class WeatherMeshEncoderConfig:
+    """
+    Configuration for `WeatherMeshEncoder`.
+
+    Attributes:
+        input_channels_2d: Number of channels of the surface (2D) input.
+        input_channels_3d: Number of channels of the pressure level (3D) input.
+        latent_dim: Channel width of the latent space the encoder projects into.
+        n_pressure_levels: Number of pressure levels of the 3D input. Kept as part of the
+            configuration; the encoder currently accepts it without using it to size any
+            layer, because the 3D path preserves depth.
+        num_conv_blocks: Number of `ConvDownBlock` stages in each of the two paths.
+        hidden_dim: Base channel width. Stage ``i`` outputs ``hidden_dim * 2 ** (i + 1)``
+            channels.
+        kernel_size: Neighborhood attention window as ``(depth, height, width)``.
+        num_heads: Number of attention heads per neighborhood attention layer.
+        num_transformer_layers: Number of neighborhood attention layers applied to the latent.
+    """
+
     input_channels_2d: int
     input_channels_3d: int
     latent_dim: int
@@ -27,13 +45,38 @@ class WeatherMeshEncoderConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMeshEncoder":
+        """
+        Build the encoder configuration from a plain dictionary.
+
+        Args:
+            json: Mapping whose keys match the fields of this dataclass.
+
+        Returns:
+            The `WeatherMeshEncoderConfig` deserialized by dacite.
+        """
         return dacite.from_dict(data_class=WeatherMeshEncoderConfig, data=json)
 
     def to_json(self) -> dict:
+        """
+        Convert the configuration into a plain dictionary.
+
+        Returns:
+            A dictionary with one entry per dataclass field.
+        """
         return dacite.asdict(self)
 
 
 class WeatherMeshEncoder(nn.Module):
+    """
+    Encoder that maps surface and pressure level fields into a single latent volume.
+
+    Surface data is downsampled by a stack of 2D `ConvDownBlock` layers and pressure level
+    data by an equivalent stack of 3D blocks that use ``stride=(1, 2, 2)`` so that the
+    vertical dimension is preserved. The surface features are appended to the pressure
+    features as one extra level along the depth axis, projected to ``latent_dim`` by a 1x1x1
+    convolution and refined by a stack of 3D neighborhood attention layers.
+    """
+
     def __init__(
         self,
         input_channels_2d: int,
@@ -46,6 +89,24 @@ class WeatherMeshEncoder(nn.Module):
         num_heads: int = 8,
         num_transformer_layers: int = 3,
     ):
+        """
+        Build the surface path, the pressure level path and the latent attention stack.
+
+        Args:
+            input_channels_2d: Number of channels of the surface (2D) input.
+            input_channels_3d: Number of channels of the pressure level (3D) input.
+            latent_dim: Channel width of the latent space the encoder projects into.
+            n_pressure_levels: Number of pressure levels of the 3D input. Accepted as part of
+                the interface; it is not used to size any layer, because the 3D path keeps the
+                depth of its input.
+            num_conv_blocks: Number of `ConvDownBlock` stages in each of the two paths.
+            hidden_dim: Base channel width. Stage ``i`` outputs ``hidden_dim * 2 ** (i + 1)``
+                channels.
+            kernel_size: Neighborhood attention window as ``(depth, height, width)``.
+            num_heads: Number of attention heads per neighborhood attention layer.
+            num_transformer_layers: Number of neighborhood attention layers applied to the
+                latent.
+        """
         super().__init__()
 
         # Surface (2D) path
@@ -86,6 +147,18 @@ class WeatherMeshEncoder(nn.Module):
         self.to_latent = nn.Conv3d(hidden_dim * (2**num_conv_blocks), latent_dim, kernel_size=1)
 
     def forward(self, surface: torch.Tensor, pressure: torch.Tensor) -> torch.Tensor:
+        """
+        Encode one surface field and one pressure level field into a latent volume.
+
+        Args:
+            surface: Surface tensor of shape ``(B, input_channels_2d, H, W)``.
+            pressure: Pressure level tensor of shape ``(B, input_channels_3d, D, H, W)``.
+
+        Returns:
+            Latent tensor of shape ``(B, D + 1, H', W', latent_dim)``, where ``H'`` and ``W'``
+            are the horizontal sizes after ``num_conv_blocks`` downsampling stages and the
+            extra level along the depth axis carries the encoded surface features.
+        """
         # Process surface data
         for block in self.surface_path:
             surface = block(surface)

--- a/graph_weather/models/weathermesh/encoder.py
+++ b/graph_weather/models/weathermesh/encoder.py
@@ -62,6 +62,11 @@ class WeatherMeshEncoderConfig:
 
         Returns:
             A dictionary with one entry per dataclass field.
+
+        Note:
+            ``dacite`` does not provide ``asdict``, so this currently raises
+            ``AttributeError``. Flagged in the pull request that added this
+            docstring; the change itself touches docstrings only.
         """
         return dacite.asdict(self)
 

--- a/graph_weather/models/weathermesh/layers.py
+++ b/graph_weather/models/weathermesh/layers.py
@@ -10,6 +10,7 @@ import torch.nn.functional as F
 class ConvDownBlock(nn.Module):
     """
     Downsampling convolutional block with residual connection.
+
     Can handle both 2D and 3D inputs.
     """
 
@@ -24,6 +25,23 @@ class ConvDownBlock(nn.Module):
         groups: int = 1,
         activation: nn.Module = nn.GELU(),
     ):
+        """
+        Build the two convolutions, their normalizations and the residual projection.
+
+        Args:
+            in_channels: Number of channels of the input tensor.
+            out_channels: Number of channels produced by the block.
+            is_3d: If True use `nn.Conv3d` and `nn.BatchNorm3d`, otherwise their 2D versions.
+            kernel_size: Kernel size of both convolutions.
+            stride: Stride of the second convolution and of the residual projection, so it
+                also sets how much the block downsamples. Accepts a tuple such as
+                ``(1, 2, 2)`` to keep the depth of a 3D input.
+            padding: Padding of both convolutions.
+            groups: Number of groups of both convolutions.
+            activation: Module applied after the first convolution and after the residual
+                addition. The default value is shared by every block that does not override
+                it, which is safe because `nn.GELU` holds no parameters.
+        """
         super().__init__()
 
         Conv = nn.Conv3d if is_3d else nn.Conv2d
@@ -58,6 +76,17 @@ class ConvDownBlock(nn.Module):
         self.bn_down = Norm(out_channels)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Downsample the input and add the projected residual.
+
+        Args:
+            x: Input tensor of shape ``(B, in_channels, H, W)``, or
+                ``(B, in_channels, D, H, W)`` when the block was built with ``is_3d=True``.
+
+        Returns:
+            A tensor with ``out_channels`` channels whose strided dimensions have been
+            divided by ``stride``.
+        """
         identity = self.bn_down(self.downsample(x))
 
         out = self.conv1(x)
@@ -89,6 +118,23 @@ class ConvUpBlock(nn.Module):
         groups: int = 1,
         activation: nn.Module = nn.GELU(),
     ):
+        """
+        Build the two convolutions, their normalizations and the residual projection.
+
+        Args:
+            in_channels: Number of channels of the input tensor.
+            out_channels: Number of channels produced by the block.
+            is_3d: If True use `nn.Conv3d` and `nn.BatchNorm3d`, otherwise their 2D versions,
+                and interpolate the height and width only so that depth is preserved.
+            kernel_size: Kernel size of both convolutions.
+            scale_factor: Factor by which the height and width are interpolated before the
+                convolutions.
+            padding: Padding of both convolutions.
+            groups: Number of groups of both convolutions.
+            activation: Module applied after the first convolution and after the residual
+                addition. The default value is shared by every block that does not override
+                it, which is safe because `nn.GELU` holds no parameters.
+        """
         super().__init__()
 
         Conv = nn.Conv3d if is_3d else nn.Conv2d
@@ -125,6 +171,18 @@ class ConvUpBlock(nn.Module):
         self.bn_up = Norm(out_channels)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """
+        Interpolate the input, run the convolutions and add the projected residual.
+
+        Args:
+            x: Input tensor of shape ``(B, in_channels, H, W)``, or
+                ``(B, in_channels, D, H, W)`` when the block was built with ``is_3d=True``.
+
+        Returns:
+            A tensor with ``out_channels`` channels whose height and width have been
+            multiplied by ``scale_factor``. A 3D input keeps its depth, because the
+            interpolation uses a scale of ``(1, scale_factor, scale_factor)``.
+        """
         # Upsample input
         if self.is_3d:
             x = F.interpolate(

--- a/graph_weather/models/weathermesh/processor.py
+++ b/graph_weather/models/weathermesh/processor.py
@@ -45,6 +45,11 @@ class WeatherMeshProcessorConfig:
 
         Returns:
             A dictionary with one entry per dataclass field.
+
+        Note:
+            ``dacite`` does not provide ``asdict``, so this currently raises
+            ``AttributeError``. Flagged in the pull request that added this
+            docstring; the change itself touches docstrings only.
         """
         return dacite.asdict(self)
 

--- a/graph_weather/models/weathermesh/processor.py
+++ b/graph_weather/models/weathermesh/processor.py
@@ -11,6 +11,16 @@ from natten import NeighborhoodAttention3D
 
 @dataclass
 class WeatherMeshProcessorConfig:
+    """
+    Configuration for `WeatherMeshProcessor`.
+
+    Attributes:
+        latent_dim: Channel width of the latent volume the processor operates on.
+        n_layers: Number of stacked neighborhood attention layers.
+        kernel: Neighborhood attention window as ``(depth, height, width)``.
+        num_heads: Number of attention heads per layer.
+    """
+
     latent_dim: int
     n_layers: int
     kernel: tuple
@@ -18,14 +28,46 @@ class WeatherMeshProcessorConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMeshProcessor":
+        """
+        Build the processor configuration from a plain dictionary.
+
+        Args:
+            json: Mapping whose keys match the fields of this dataclass.
+
+        Returns:
+            The `WeatherMeshProcessorConfig` deserialized by dacite.
+        """
         return dacite.from_dict(data_class=WeatherMeshProcessorConfig, data=json)
 
     def to_json(self) -> dict:
+        """
+        Convert the configuration into a plain dictionary.
+
+        Returns:
+            A dictionary with one entry per dataclass field.
+        """
         return dacite.asdict(self)
 
 
 class WeatherMeshProcessor(nn.Module):
+    """
+    Processor that advances the latent state with 3D neighborhood attention.
+
+    It is a plain stack of `NeighborhoodAttention3D` layers, each attending over a local
+    ``kernel`` sized window in depth, height and width. Shape and channel width are unchanged,
+    so one processor can be applied repeatedly to roll a forecast forward.
+    """
+
     def __init__(self, latent_dim, n_layers=10, kernel=(5, 7, 7), num_heads=8):
+        """
+        Build the stack of neighborhood attention layers.
+
+        Args:
+            latent_dim: Channel width of the latent volume the processor operates on.
+            n_layers: Number of stacked neighborhood attention layers.
+            kernel: Neighborhood attention window as ``(depth, height, width)``.
+            num_heads: Number of attention heads per layer.
+        """
         super().__init__()
 
         self.layers = nn.ModuleList(
@@ -40,6 +82,15 @@ class WeatherMeshProcessor(nn.Module):
         )
 
     def forward(self, x):
+        """
+        Apply every neighborhood attention layer in sequence.
+
+        Args:
+            x: Latent tensor of shape ``(B, D, H, W, latent_dim)``.
+
+        Returns:
+            A tensor of the same shape as ``x``.
+        """
         for layer in self.layers:
             x = layer(x)
         return x

--- a/graph_weather/models/weathermesh/weathermesh2.py
+++ b/graph_weather/models/weathermesh/weathermesh2.py
@@ -101,6 +101,11 @@ class WeatherMeshConfig:
 
         Returns:
             A dictionary with one entry per dataclass field.
+
+        Note:
+            ``dacite`` does not provide ``asdict``, so this currently raises
+            ``AttributeError``. Flagged in the pull request that added this
+            docstring; the change itself touches docstrings only.
         """
         return dacite.asdict(self)
 

--- a/graph_weather/models/weathermesh/weathermesh2.py
+++ b/graph_weather/models/weathermesh/weathermesh2.py
@@ -19,9 +19,13 @@ from graph_weather.models.weathermesh.processor import (
 """
 Notes on implementation
 
-To make NATTEN work on a sphere, we implement our own circular padding. At the poles, we use the bump attention behavior from NATTEN. For position encoding of tokens, we use Rotary Embeddings.
+To make NATTEN work on a sphere, we implement our own circular padding. At the poles, we use
+the bump attention behavior from NATTEN. For position encoding of tokens, we use Rotary
+Embeddings.
 
-In the default configuration of WeatherMesh 2, the NATTEN window is 5,7,7 in depth, width, height, corresponding to a physical size of 14 degrees longitude and latitude. WeatherMesh 2 contains two processors: a 6hr and a 1hr processor. Each is 10 NATTEN layers deep.
+In the default configuration of WeatherMesh 2, the NATTEN window is 5,7,7 in depth, width,
+height, corresponding to a physical size of 14 degrees longitude and latitude. WeatherMesh 2
+contains two processors: a 6hr and a 1hr processor. Each is 10 NATTEN layers deep.
 
 Training: distributed shampoo: https://github.com/facebookresearch/optimizers/blob/main/distributed_shampoo/README.md
 
@@ -34,6 +38,32 @@ TODO: Add bump attention and rotary embeddings for the circular padding and posi
 
 @dataclass
 class WeatherMeshConfig:
+    """
+    Configuration for the full `WeatherMesh` model.
+
+    Holds the configs of the three sub-modules plus the flat set of values used to build
+    default sub-modules when none are supplied.
+
+    Attributes:
+        encoder: Configuration of the encoder.
+        processors: One configuration per processor.
+        decoder: Configuration of the decoder.
+        timesteps: Lead times, in hours, covered by the processors; one entry per processor.
+        surface_channels: Number of channels of the surface (2D) fields.
+        pressure_channels: Number of channels of the pressure level (3D) fields.
+        pressure_levels: Number of pressure levels of the 3D fields.
+        latent_dim: Channel width of the latent space shared by all three sub-modules.
+        encoder_num_conv_blocks: Number of downsampling stages per encoder path.
+        encoder_num_transformer_layers: Number of encoder neighborhood attention layers.
+        encoder_hidden_dim: Base channel width of the encoder convolution stages.
+        decoder_num_conv_blocks: Number of upsampling stages per decoder path.
+        decoder_num_transformer_layers: Number of decoder neighborhood attention layers.
+        decoder_hidden_dim: Base channel width of the decoder convolution stages.
+        processor_num_layers: Number of neighborhood attention layers per processor.
+        kernel: Neighborhood attention window as ``(depth, height, width)``.
+        num_heads: Number of attention heads per neighborhood attention layer.
+    """
+
     encoder: WeatherMeshEncoderConfig
     processors: List[WeatherMeshProcessorConfig]
     decoder: WeatherMeshDecoderConfig
@@ -54,19 +84,51 @@ class WeatherMeshConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMesh":
+        """
+        Build the model configuration from a plain dictionary.
+
+        Args:
+            json: Mapping whose keys match the fields of this dataclass.
+
+        Returns:
+            The `WeatherMeshConfig` deserialized by dacite.
+        """
         return dacite.from_dict(data_class=WeatherMeshConfig, data=json)
 
     def to_json(self) -> dict:
+        """
+        Convert the configuration into a plain dictionary.
+
+        Returns:
+            A dictionary with one entry per dataclass field.
+        """
         return dacite.asdict(self)
 
 
 @dataclass
 class WeatherMeshOutput:
+    """
+    Result of a `WeatherMesh` forward pass.
+
+    Attributes:
+        surface: Surface field of shape ``(B, surface_channels, H, W)``.
+        pressure: Pressure level field of shape ``(B, pressure_channels, D, H, W)``.
+    """
+
     surface: torch.Tensor
     pressure: torch.Tensor
 
 
 class WeatherMesh(nn.Module):
+    """
+    WeatherMesh forecasting model: encoder, one or more processors and a decoder.
+
+    The encoder maps the surface and pressure level fields into a single latent volume, the
+    processors advance that latent with 3D neighborhood attention, and the decoder maps it
+    back to surface and pressure level fields. Each sub-module can be passed in ready-made;
+    otherwise it is built from the remaining arguments.
+    """
+
     def __init__(
         self,
         encoder: nn.Module | None,
@@ -87,6 +149,40 @@ class WeatherMesh(nn.Module):
         kernel: tuple | None,
         num_heads: int | None,
     ):
+        """
+        Assemble the model, building any sub-module that was not supplied.
+
+        Args:
+            encoder: Ready-made encoder. If None, a `WeatherMeshEncoder` is built from the
+                ``surface_channels``, ``pressure_channels``, ``pressure_levels``,
+                ``latent_dim``, ``encoder_*``, ``kernel`` and ``num_heads`` arguments.
+            processors: Ready-made processors, one per entry of ``timesteps``. If None, one
+                `WeatherMeshProcessor` per timestep is built from ``latent_dim``,
+                ``processor_num_layers``, ``kernel`` and ``num_heads``. Either way the
+                processors are kept in a plain list rather than an `nn.ModuleList`.
+            decoder: Ready-made decoder. If None, a `WeatherMeshDecoder` is built from the
+                ``latent_dim``, ``surface_channels``, ``pressure_channels``, ``decoder_*``,
+                ``kernel`` and ``num_heads`` arguments.
+            timesteps: Lead times, in hours, covered by the processors; its length sets how
+                many processors are built and is checked against ``processors``.
+            surface_channels: Number of channels of the surface (2D) fields.
+            pressure_channels: Number of channels of the pressure level (3D) fields.
+            pressure_levels: Number of pressure levels of the 3D fields.
+            latent_dim: Channel width of the latent space shared by all three sub-modules.
+            encoder_num_conv_blocks: Number of downsampling stages per encoder path.
+            encoder_num_transformer_layers: Number of encoder neighborhood attention layers.
+            encoder_hidden_dim: Base channel width of the encoder convolution stages.
+            decoder_num_conv_blocks: Number of upsampling stages per decoder path.
+            decoder_num_transformer_layers: Number of decoder neighborhood attention layers.
+            decoder_hidden_dim: Base channel width of the decoder convolution stages.
+            processor_num_layers: Number of neighborhood attention layers per processor.
+            kernel: Neighborhood attention window as ``(depth, height, width)``.
+            num_heads: Number of attention heads per neighborhood attention layer.
+
+        Raises:
+            AssertionError: If ``processors`` is supplied and its length differs from the
+                length of ``timesteps``.
+        """
         super().__init__()
         if encoder is not None:
             self.encoder = encoder
@@ -135,6 +231,22 @@ class WeatherMesh(nn.Module):
     def forward(
         self, surface: torch.Tensor, pressure: torch.Tensor, forecast_steps: int
     ) -> WeatherMeshOutput:
+        """
+        Roll the forecast forward and decode the final latent state.
+
+        The inputs are encoded once. Every processor is then applied in sequence, and that
+        whole sequence is repeated ``forecast_steps`` times, so the lead time advanced is
+        ``forecast_steps`` times the sum of ``self.timesteps``. Only the final state is
+        decoded; intermediate states are not returned.
+
+        Args:
+            surface: Surface tensor of shape ``(B, surface_channels, H, W)``.
+            pressure: Pressure level tensor of shape ``(B, pressure_channels, D, H, W)``.
+            forecast_steps: Number of times the full processor sequence is applied.
+
+        Returns:
+            A `WeatherMeshOutput` holding the decoded surface and pressure level fields.
+        """
         # Encode input
         latent = self.encoder(surface, pressure)
 

--- a/graph_weather/models/weathermesh/weathermesh2.py
+++ b/graph_weather/models/weathermesh/weathermesh2.py
@@ -23,8 +23,9 @@ To make NATTEN work on a sphere, we implement our own circular padding. At the p
 the bump attention behavior from NATTEN. For position encoding of tokens, we use Rotary
 Embeddings.
 
-In the default configuration of WeatherMesh 2, the NATTEN window is 5,7,7 in depth, width,
-height, corresponding to a physical size of 14 degrees longitude and latitude. WeatherMesh 2
+In the default configuration of WeatherMesh 2, the NATTEN window is 5,7,7 in depth, height,
+and width, corresponding to a physical size of 14 degrees longitude and latitude.
+WeatherMesh 2
 contains two processors: a 6hr and a 1hr processor. Each is 10 NATTEN layers deep.
 
 Training: distributed shampoo: https://github.com/facebookresearch/optimizers/blob/main/distributed_shampoo/README.md

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,14 @@ long_description = (this_directory / "README.md").read_text()
 
 # Read version from pyproject.toml (single source of truth)
 def get_version():
+    """Read the package version from pyproject.toml.
+
+    Returns:
+        str: The version declared by the ``version`` field of pyproject.toml.
+
+    Raises:
+        RuntimeError: If no version string is found in pyproject.toml.
+    """
     pyproject_path = this_directory / "pyproject.toml"
     content = pyproject_path.read_text()
     match = re.search(r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE)

--- a/train/era5.py
+++ b/train/era5.py
@@ -24,7 +24,7 @@ class LitFengWuGHR(pl.LightningModule):
     LightningModule for graph-based weather forecasting.
 
     Attributes:
-        model (GraphWeatherForecaster): Graph weather forecaster model.
+        model (MetaModel): Image-based meta model used for the forecast step.
         criterion (NormalizedMSELoss): Loss criterion for training.
         lr : Learning rate for optimizer.
 

--- a/train/era5.py
+++ b/train/era5.py
@@ -1,3 +1,10 @@
+"""Train a MetaModel forecaster on ARCO-ERA5 reanalysis data.
+
+Running this file as a script downloads a slice of the public ARCO-ERA5 zarr store, coarsens
+it onto a reduced lat/lon grid, trains :class:`LitFengWuGHR` for a single time step with
+Lightning, and writes the resulting weights to ``./checkpoints/best.pt``.
+"""
+
 from pathlib import Path
 
 import numpy as np
@@ -44,12 +51,24 @@ class LitFengWuGHR(pl.LightningModule):
         """
         Initialize the LitFengWuGHR object with the required args.
 
+        All arguments other than ``lr`` and ``feature_dim`` are forwarded to
+        :class:`~graph_weather.models.fengwu_ghr.layers.MetaModel`, which interpolates the
+        point cloud onto a regular grid and runs a vision-transformer backbone over it.
+
         Args:
-            lat_lons : List of latitude and longitude values.
-            feature_dim : Dimensionality of the input features.
-            aux_dim : Dimensionality of auxiliary features.
-            hidden_dim : Dimensionality of hidden layers in the model.
-            num_blocks : Number of graph convolutional blocks in the model.
+            lat_lons : List of latitude and longitude values, one pair per node of the input
+                point cloud.
+            channels (int): Number of physical variables carried by each node.
+            image_size : Height and width of the regular grid the point cloud is interpolated
+                onto. A single int is used for both dimensions.
+            patch_size : Height and width of the patches the grid is split into before the
+                transformer. Both grid dimensions must be divisible by it.
+            depth : Number of transformer layers in the backbone.
+            heads : Number of attention heads per transformer layer.
+            mlp_dim : Hidden dimensionality of the feed-forward block in each transformer
+                layer.
+            feature_dim : Length of the per-feature variance vector handed to
+                :class:`NormalizedMSELoss`; a vector of ones of this length is used.
             lr (float): Learning rate for optimizer.
         """
         super().__init__()
@@ -114,8 +133,14 @@ class Era5Dataset(Dataset):
 
     def __init__(self, xarr, transform=None):
         """
-        Arguments:
-            #TODO
+        Initialize the dataset by eagerly loading and normalizing the whole slice.
+
+        Args:
+            xarr (xarray.Dataset): Reanalysis slice to train on. It is stacked into a dense
+                array of shape ``[C, T, H, W]``, min-max scaled using the minimum and maximum
+                taken over the leading axis, and then rearranged to ``[T, H * W, C]`` so that
+                each time frame is a flat point cloud.
+            transform (callable, optional): Currently unused.
         """
         ds = np.asarray(xarr.to_array())
         ds = torch.from_numpy(ds)

--- a/train/lora.py
+++ b/train/lora.py
@@ -1,3 +1,10 @@
+"""Fine-tune a pretrained single-step forecaster into a multi-step one with LoRA.
+
+Running this file as a script loads the single-step ``MetaModel`` checkpoint written by
+``train/era5.py``, stacks one LoRA-adapted copy per additional lead time on top of it, and
+trains the resulting rollout on a slice of the public ARCO-ERA5 zarr store.
+"""
+
 from pathlib import Path
 
 import numpy as np
@@ -14,6 +21,21 @@ from graph_weather.models.losses import NormalizedMSELoss
 
 
 class LitLoRAFengWuGHR(pl.LightningModule):
+    """
+    LightningModule that rolls a single-step forecaster out over several lead times.
+
+    ``self.models`` holds one entry per lead time: the pretrained single-step
+    :class:`~graph_weather.models.fengwu_ghr.layers.MetaModel` first, followed by
+    ``time_step - 1`` :class:`~graph_weather.models.fengwu_ghr.layers.LoRAModule` wrappers
+    built from it, each replacing the linear layers with rank-``rank`` LoRA layers. The
+    forward pass applies them one after another, feeding each step its predecessor's output.
+
+    Attributes:
+        models (nn.ModuleList): The per-step models applied in sequence.
+        criterion (NormalizedMSELoss): Loss criterion for training.
+        lr : Learning rate for optimizer.
+    """
+
     def __init__(
         self,
         lat_lons: list,
@@ -30,6 +52,34 @@ class LitLoRAFengWuGHR(pl.LightningModule):
         feature_dim: int = 605,  # TODO where does this come from?
         lr: float = 3e-4,
     ):
+        """
+        Build the single-step backbone and the LoRA-adapted models stacked on top of it.
+
+        The keyword arguments describing the architecture must match the ones used to train
+        ``single_step_model_state_dict``, since that state dict is loaded into a freshly
+        constructed :class:`~graph_weather.models.fengwu_ghr.layers.MetaModel`.
+
+        Args:
+            lat_lons (list): List of latitude and longitude values, one pair per node of the
+                input point cloud.
+            single_step_model_state_dict (dict): State dict of an already trained single-step
+                model, loaded into the backbone before the LoRA wrappers are built.
+            time_step (int): Number of lead times to roll out. Must be greater than 1, since
+                1 is the plain single-step model.
+            rank (int): Rank of the LoRA layers.
+            channels (int): Number of physical variables carried by each node.
+            image_size : Height and width of the regular grid the point cloud is interpolated
+                onto. A single int is used for both dimensions.
+            patch_size : Height and width of the patches the grid is split into before the
+                transformer. Both grid dimensions must be divisible by it.
+            depth : Number of transformer layers in the backbone.
+            heads : Number of attention heads per transformer layer.
+            mlp_dim : Hidden dimensionality of the feed-forward block in each transformer
+                layer.
+            feature_dim (int): Length of the per-feature variance vector handed to
+                :class:`NormalizedMSELoss`; a vector of ones of this length is used.
+            lr (float): Learning rate for optimizer.
+        """
         super().__init__()
         assert (
             time_step > 1
@@ -54,6 +104,17 @@ class LitLoRAFengWuGHR(pl.LightningModule):
         self.save_hyperparameters()
 
     def forward(self, x):
+        """
+        Roll the chain of models out, feeding each step the previous step's prediction.
+
+        Args:
+            x (torch.Tensor): Input frame of shape ``[B, N, C]``, where ``N`` is the number of
+                lat/lon nodes and ``C`` the number of physical variables.
+
+        Returns:
+            torch.Tensor: Prediction of every lead time, stacked along a new axis at dim 1,
+            giving shape ``[B, time_step, N, C]``.
+        """
         ys = []
         for t, model in enumerate(self.models):
             x = model(x)
@@ -61,6 +122,20 @@ class LitLoRAFengWuGHR(pl.LightningModule):
         return torch.stack(ys, dim=1)
 
     def training_step(self, batch, batch_idx):
+        """
+        Run one training step over a window of consecutive frames.
+
+        Batches holding any NaN are skipped by returning ``None``, which tells Lightning to
+        drop the step.
+
+        Args:
+            batch (torch.Tensor): Frames of shape ``[B, time_step + 1, N, C]``. The first
+                frame is the input and the remaining ones are the targets, one per lead time.
+            batch_idx (int): Index of the current batch.
+
+        Returns:
+            torch.Tensor: Loss tensor, or ``None`` when the batch contained NaN values.
+        """
         if torch.isnan(batch).any():
             return None
         x, ys = batch[:, 0, ...], batch[:, 1:, ...]
@@ -71,11 +146,33 @@ class LitLoRAFengWuGHR(pl.LightningModule):
         return loss
 
     def configure_optimizers(self):
+        """
+        Configure the optimizer.
+
+        Returns:
+            torch.optim.Optimizer: ``AdamW`` over every parameter of this module, using the
+            learning rate given to the constructor.
+        """
         return torch.optim.AdamW(self.parameters(), lr=self.lr)
 
 
 class Era5Dataset(Dataset):
+    """Era5 dataset yielding windows of consecutive time frames."""
+
     def __init__(self, xarr, time_step=1, transform=None):
+        """
+        Initialize the dataset by eagerly loading and normalizing the whole slice.
+
+        Args:
+            xarr (xarray.Dataset): Reanalysis slice to train on. It is stacked into a dense
+                array of shape ``[C, T, H, W]``, min-max scaled using the minimum and maximum
+                taken over the leading axis, and then rearranged to ``[T, H * W, C]`` so that
+                each time frame is a flat point cloud.
+            time_step (int): Number of lead times per sample. Must be greater than 0. It
+                shortens the reported length, so that the frames following an index are
+                always available as targets.
+            transform (callable, optional): Currently unused.
+        """
         assert time_step > 0, "Time step must be greater than 0."
         ds = np.asarray(xarr.to_array())
         ds = torch.from_numpy(ds)

--- a/train/lora.py
+++ b/train/lora.py
@@ -27,7 +27,8 @@ class LitLoRAFengWuGHR(pl.LightningModule):
     ``self.models`` holds one entry per lead time: the pretrained single-step
     :class:`~graph_weather.models.fengwu_ghr.layers.MetaModel` first, followed by
     ``time_step - 1`` :class:`~graph_weather.models.fengwu_ghr.layers.LoRAModule` wrappers
-    built from it, each replacing the linear layers with rank-``rank`` LoRA layers. The
+    built from it, each attaching rank-``rank`` LoRA layers to the linear layers it can
+    reach as direct attributes (see `LoRAModule`). The
     forward pass applies them one after another, feeding each step its predecessor's output.
 
     Attributes:


### PR DESCRIPTION
# Pull Request

## Description

`pre-commit.ci` has been failing on `main` since at least 2026-07-13, which makes the `pre-commit.ci - pr` check red on **every** open pull request regardless of what it changes. The `ruff` hook reports 156 errors and `ruff check --fix --diff` produces an empty diff, so `autofix_prs` cannot clear any of them.

This adds the missing Google-style docstrings, inserts the blank line after the summary line where `D205` asked for it, fills in the two undocumented `efficient_batching` arguments, and wraps the 12 over-long lines.

```
before:  Found 156 errors.
after:   All checks passed!
```

Fixes #244

## No behavior changes

Every changed file was compared against `upstream/main` by parsing both versions with `ast`, discarding **all** string-literal expression statements (docstrings, and one module-level notes block that is written as a bare string), and diffing `ast.dump` of the result:

- executable AST identical: **33/33**
- comment text identical after whitespace normalization: **33/33**
- `black 26.5.1 --line-length 100 --check .` → 115 files would be left unchanged
- no non-Python file is touched

## Docstrings that were wrong, not just missing

Thirteen existing statements did not match the code. They are corrected rather than reformatted, each verified against the source:

| file | said | actually |
| --- | --- | --- |
| `cafa/processor.py` | `forward` takes `(batch, height, width, channels)` | first op is `rearrange(x, "b c h w -> b h w c")`, so it takes `(batch, channels, height, width)` |
| `cafa/encoder.py` | argument `input_channel` | the parameter is `input_channels` — this is what `D417` was flagging |
| `cafa/decoder.py` | `FactorizedTransformer` | the package defines `CaFAProcessor` and `FactorizedTransformerBlock` |
| `train/era5.py` | `LitFengWuGHR.__init__` takes `aux_dim`, `hidden_dim`, `num_blocks` | none of the three exist; six real parameters were undocumented |
| `train/era5.py` | `self.model` is a `GraphWeatherForecaster` | it is a `MetaModel` |
| `aurora/processor.py` | `attention_dropout`, `layer_norm_eps`, `num_cross_attention_layers`, `max_seq_len`, `qk_head_dim` take effect | `PerceiverProcessor.__init__` reads only `input_dim`, `d_model`, `num_attention_heads`, `hidden_dropout`, `activation_fn`, `num_self_attention_layers`, `latent_dim`; the rest are validated in `__post_init__` at most |
| `aurora/processor.py` | `input_dim` matches the Swin3D output | `Swin3DEncoder` defaults to `96`, `ProcessorConfig` to `256` |
| `aurora/model.py` | `spatial_correlation_loss` averages over neighboring pairs | `torch.mean(nearby_mask * ...)` divides by every pair, masked-out zeros included |
| `aurora/model.py` | `PointEncoder` is order-invariant | point-wise MLPs plus addition are permutation-**equivariant** |
| `aurora/model.py` | `forward` returns `num_points` rows | the encoder truncates to `max_seq_len`, so it is `min(num_points, max_seq_len)` |
| `aurora/decoder.py` | the transposed convolution upscales | `kernel_size=3, stride=1, padding=1` preserves D, H and W; only the channel count changes |
| `fengwu_ghr/layers.py` | `LoRAModule` replaces linear layers | `setattr(model, name, ...)` with the dotted names from `named_modules` only substitutes direct attributes |
| `fengwu_ghr/layers.py` | the batcher cuts the image into sub-images | `"b c (h s_h) (w s_w) -> (b s_h s_w) c h w"` puts `s_h` on the fast axis, so each sub-image is a strided sample, not a contiguous tile |

Two more were adjusted for accuracy: `posemb_sincos_2d` documented `dim` as any multiple of 4, but `dim == 4` passes the assertion and makes `dim // 4 - 1` zero; and the `weathermesh2` implementation note gave the NATTEN window as `depth, width, height` while the encoder hands the processor a `B D H W C` latent, so it is `(depth, height, width)` as every other docstring in that package says (both are 7 by default, so nothing observable changes).

## Bugs found while writing this, left alone

Documenting these modules surfaced seven real defects. None are touched here, because this change is docstrings only — but they are worth knowing about, and I am happy to open follow-up PRs for any of them if that would help:

1. `weathermesh/{encoder,decoder,processor,weathermesh2}.py` — all four `to_json` methods call `dacite.asdict`, which `dacite` does not export (`from_dict` is the only converter). They raise `AttributeError`. `dataclasses.asdict` is the drop-in.
2. `fengwu_ghr/layers.py` — `LoRAModule` iterates `named_modules()` and calls `setattr(model, name, ...)` with dotted names, so nested linear layers keep running unchanged; it also mutates `_modules` during that traversal.
3. `fengwu_ghr/layers.py` — `LoRALayer.forward` computes `self.B @ self.A @ x`, which does not apply to the trailing `in_features` axis for inputs with leading dimensions.
4. `aurora/model.py` — `spatial_correlation_loss` does `cdist` on `(B*N, 2)` and then `view(B, N, N)`; the element counts only match when `B == 1`.
5. `aurora/processor.py` — the 4D branch of `PerceiverProcessor.forward` uses `rearrange(x, "b s h w -> b (s h w) c")`, where `c` is not bound.
6. `layers/constraint_layer.py` — the constructor defaults `constraint_type="none"`, which `forward` has no branch for, so the default raises `ValueError`.
7. `weathermesh2.py` — `self.processors` is a plain list in both constructor branches, so those modules are invisible to `state_dict()`, `.to(device)` and `.train()`.

## How Has This Been Tested?

- [x] Yes

- `ruff check .` with the pinned `v0.15.15` → `All checks passed!` (was `Found 156 errors.`)
- `black 26.5.1 --line-length 100 --check .` → unchanged
- the AST and comment-text comparison described above, over all 33 changed files
- `pytest` is red on this branch, but it is red on `main` too: it is the collection-time segfault of #232 (exit 139 before any test runs), which #241 addresses. Docstrings cannot cause it, and the executable AST here is identical to `main`.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works — the `ruff` hook is the test; there is no runtime behavior to cover
- [x] I have checked my code and corrected any misspellings

Happy to split this per-module if a single sweep is awkward to review — just say the word.
