### PR TITLE
fix: repair three runtime defects in the WeatherMesh and Aurora models

### DIFF
--- a/.github/workflows/workflows.yaml
+++ b/.github/workflows/workflows.yaml
@@ -28,6 +28,7 @@ jobs:
           pixi run -e ${{ matrix.environment }} installpyg
           pixi run -e ${{ matrix.environment }} pip install coverage==7.4.3 pytest-cov
           pixi run -e ${{ matrix.environment }} installnat
+          pixi run -e ${{ matrix.environment }} installnnja
           pixi run -e ${{ matrix.environment }} install
       - name: Setup with pytest-cov
         run: |

--- a/graph_weather/data/dataloader.py
+++ b/graph_weather/data/dataloader.py
@@ -99,7 +99,7 @@ class AnalysisDataset(Dataset):
         np.cos(day_of_year)
         solar_times = [np.array([extraterrestrial_irrad(date, lat, lon) for lat, lon in lat_lons])]
         for when in pd.date_range(
-            date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1H"
+            date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1h"
         ):
             solar_times.append(
                 np.array([extraterrestrial_irrad(when, lat, lon) for lat, lon in lat_lons])
@@ -112,7 +112,7 @@ class AnalysisDataset(Dataset):
             np.array([extraterrestrial_irrad(end_date, lat, lon) for lat, lon in lat_lons])
         ]
         for when in pd.date_range(
-            end_date - pd.Timedelta("12 hours"), end_date + pd.Timedelta("12 hours"), freq="1H"
+            end_date - pd.Timedelta("12 hours"), end_date + pd.Timedelta("12 hours"), freq="1h"
         ):
             end_solar_times.append(
                 np.array([extraterrestrial_irrad(when, lat, lon) for lat, lon in lat_lons])

--- a/graph_weather/data/weather_station_reader.py
+++ b/graph_weather/data/weather_station_reader.py
@@ -681,14 +681,14 @@ class WeatherStationReader:
         return interpolated
 
     def resample_observations(
-        self, observations: Optional[xr.Dataset], freq: str = "1H", aggregation: str = "mean"
+        self, observations: Optional[xr.Dataset], freq: str = "1h", aggregation: str = "mean"
     ) -> Optional[xr.Dataset]:
         """
         Resample observations to a different time frequency.
 
         Args:
             observations: Dataset with observations.
-            freq: Target frequency ('1H', '1D', etc.).
+            freq: Target frequency ('1h', '1D', etc.).
             aggregation: Aggregation method ('mean', 'sum', 'min', 'max').
 
         Returns:

--- a/graph_weather/models/aurora/model.py
+++ b/graph_weather/models/aurora/model.py
@@ -130,6 +130,9 @@ class EarthSystemLoss(nn.Module):
     def spatial_correlation_loss(
         self, pred: torch.Tensor, target: torch.Tensor, points: torch.Tensor
     ) -> torch.Tensor:
+        if points.dim() != 3:
+            raise ValueError(f"points must be (batch, num_points, 2), got {tuple(points.shape)}")
+
         # Compute pairwise distances within each batch element
         dists = torch.cdist(points, points)
 

--- a/graph_weather/models/aurora/model.py
+++ b/graph_weather/models/aurora/model.py
@@ -130,12 +130,8 @@ class EarthSystemLoss(nn.Module):
     def spatial_correlation_loss(
         self, pred: torch.Tensor, target: torch.Tensor, points: torch.Tensor
     ) -> torch.Tensor:
-        batch_size, num_points, _ = points.shape
-        points_flat = points.view(-1, 2)
-
-        # Compute pairwise distances
-        dists = torch.cdist(points_flat, points_flat)
-        dists = dists.view(batch_size, num_points, num_points)
+        # Compute pairwise distances within each batch element
+        dists = torch.cdist(points, points)
 
         # Create mask for nearby points (5 degrees threshold)
         nearby_mask = (dists < 5.0).float().unsqueeze(-1)

--- a/graph_weather/models/gencast/utils/noise.py
+++ b/graph_weather/models/gencast/utils/noise.py
@@ -38,11 +38,16 @@ def generate_isotropic_noise(num_lon: int, num_lat: int, num_samples=1, isotropi
     if isotropic:
         lmax = num_lat - 1 if extend else num_lat
         mmax = lmax + 1
-        coeffs = torch.randn(num_samples, lmax, mmax, dtype=torch.complex64) / np.sqrt(
-            (num_lat**2) // 2
-        )
         isht = th.InverseRealSHT(
             nlat=num_lat, nlon=num_lon, lmax=lmax, mmax=mmax, grid="equiangular"
+        )
+        # torch-harmonics >= 0.9.0 applies triangular truncation, which clamps mmax down
+        # to lmax, so the transform can keep fewer modes than were requested. Read the
+        # retained mode counts back off the transform instead of assuming lmax/mmax are
+        # honoured verbatim. The discarded coefficients have m > l, where the associated
+        # Legendre functions vanish, so this does not change the generated noise.
+        coeffs = torch.randn(num_samples, isht.lmax, isht.mmax, dtype=torch.complex64) / np.sqrt(
+            (num_lat**2) // 2
         )
         noise = isht(coeffs) * np.sqrt(2 * np.pi)
         noise = einops.rearrange(noise, "b lat lon -> lon lat b").numpy()

--- a/graph_weather/models/weathermesh/decoder.py
+++ b/graph_weather/models/weathermesh/decoder.py
@@ -26,7 +26,9 @@ class WeatherMeshDecoderConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMeshDecoder":
-        return dacite.from_dict(data_class=WeatherMeshDecoderConfig, data=json)
+        return dacite.from_dict(
+            data_class=WeatherMeshDecoderConfig, data=json, config=dacite.Config(cast=[tuple])
+        )
 
     def to_json(self) -> dict:
         return asdict(self)

--- a/graph_weather/models/weathermesh/decoder.py
+++ b/graph_weather/models/weathermesh/decoder.py
@@ -2,7 +2,7 @@
 Implementation based off the technical report and this repo: https://github.com/Brayden-Zhang/WeatherMesh
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import dacite
 import einops
@@ -29,7 +29,7 @@ class WeatherMeshDecoderConfig:
         return dacite.from_dict(data_class=WeatherMeshDecoderConfig, data=json)
 
     def to_json(self) -> dict:
-        return dacite.asdict(self)
+        return asdict(self)
 
 
 class WeatherMeshDecoder(nn.Module):

--- a/graph_weather/models/weathermesh/encoder.py
+++ b/graph_weather/models/weathermesh/encoder.py
@@ -2,7 +2,7 @@
 Implementation based off the technical report and this repo: https://github.com/Brayden-Zhang/WeatherMesh
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import dacite
 import einops
@@ -30,7 +30,7 @@ class WeatherMeshEncoderConfig:
         return dacite.from_dict(data_class=WeatherMeshEncoderConfig, data=json)
 
     def to_json(self) -> dict:
-        return dacite.asdict(self)
+        return asdict(self)
 
 
 class WeatherMeshEncoder(nn.Module):

--- a/graph_weather/models/weathermesh/encoder.py
+++ b/graph_weather/models/weathermesh/encoder.py
@@ -27,7 +27,9 @@ class WeatherMeshEncoderConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMeshEncoder":
-        return dacite.from_dict(data_class=WeatherMeshEncoderConfig, data=json)
+        return dacite.from_dict(
+            data_class=WeatherMeshEncoderConfig, data=json, config=dacite.Config(cast=[tuple])
+        )
 
     def to_json(self) -> dict:
         return asdict(self)

--- a/graph_weather/models/weathermesh/processor.py
+++ b/graph_weather/models/weathermesh/processor.py
@@ -18,7 +18,9 @@ class WeatherMeshProcessorConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMeshProcessor":
-        return dacite.from_dict(data_class=WeatherMeshProcessorConfig, data=json)
+        return dacite.from_dict(
+            data_class=WeatherMeshProcessorConfig, data=json, config=dacite.Config(cast=[tuple])
+        )
 
     def to_json(self) -> dict:
         return asdict(self)

--- a/graph_weather/models/weathermesh/processor.py
+++ b/graph_weather/models/weathermesh/processor.py
@@ -2,7 +2,7 @@
 Implementation based off the technical report and this repo: https://github.com/Brayden-Zhang/WeatherMesh
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 import dacite
 import torch.nn as nn
@@ -21,7 +21,7 @@ class WeatherMeshProcessorConfig:
         return dacite.from_dict(data_class=WeatherMeshProcessorConfig, data=json)
 
     def to_json(self) -> dict:
-        return dacite.asdict(self)
+        return asdict(self)
 
 
 class WeatherMeshProcessor(nn.Module):

--- a/graph_weather/models/weathermesh/weathermesh2.py
+++ b/graph_weather/models/weathermesh/weathermesh2.py
@@ -54,7 +54,9 @@ class WeatherMeshConfig:
 
     @staticmethod
     def from_json(json: dict) -> "WeatherMesh":
-        return dacite.from_dict(data_class=WeatherMeshConfig, data=json)
+        return dacite.from_dict(
+            data_class=WeatherMeshConfig, data=json, config=dacite.Config(cast=[tuple])
+        )
 
     def to_json(self) -> dict:
         return asdict(self)

--- a/graph_weather/models/weathermesh/weathermesh2.py
+++ b/graph_weather/models/weathermesh/weathermesh2.py
@@ -2,7 +2,7 @@
 Implementation based off the technical report and this repo: https://github.com/Brayden-Zhang/WeatherMesh
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import List
 
 import dacite
@@ -57,7 +57,7 @@ class WeatherMeshConfig:
         return dacite.from_dict(data_class=WeatherMeshConfig, data=json)
 
     def to_json(self) -> dict:
-        return dacite.asdict(self)
+        return asdict(self)
 
 
 @dataclass
@@ -106,17 +106,19 @@ class WeatherMesh(nn.Module):
             assert len(processors) == len(
                 timesteps
             ), "Number of processors must match number of timesteps"
-            self.processors = processors
+            self.processors = nn.ModuleList(processors)
         else:
-            self.processors = [
-                WeatherMeshProcessor(
-                    latent_dim=latent_dim,
-                    n_layers=processor_num_layers,
-                    kernel=kernel,
-                    num_heads=num_heads,
-                )
-                for _ in range(len(timesteps))
-            ]
+            self.processors = nn.ModuleList(
+                [
+                    WeatherMeshProcessor(
+                        latent_dim=latent_dim,
+                        n_layers=processor_num_layers,
+                        kernel=kernel,
+                        num_heads=num_heads,
+                    )
+                    for _ in range(len(timesteps))
+                ]
+            )
         if decoder is not None:
             self.decoder = decoder
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ platforms = ["linux-64", "osx-arm64"]
 
 [tool.pixi.dependencies]
 python = "3.12.*"
-pytorch = "2.10.*"
+pytorch = "2.10.0"
 pip = "*"
 pytest = "*"
 pre-commit = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ platforms = ["linux-64", "osx-arm64"]
 
 [tool.pixi.dependencies]
 python = "3.12.*"
+pytorch = "2.10.*"
 pip = "*"
 pytest = "*"
 pre-commit = "*"
@@ -95,8 +96,8 @@ install = "pip install --editable ."
 installnnja = "pip install git+https://github.com/brightbandtech/nnja-ai.git"
 installnat = "pip install natten"
 installnatcuda = "pip install natten==0.20.1+torch270cu128 -f https://whl.natten.org"
-installpyg = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.7.0+cpu.html"
-installpygcuda = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.7.0+cuda128.html"
+installpyg = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.10.0+cpu.html"
+installpygcuda = "pip install pyg_lib torch_scatter torch_sparse torch_cluster torch_spline_conv -f https://data.pyg.org/whl/torch-2.10.0+cu128.html"
 test = "pytest"
 format = "ruff format"
 

--- a/tests/test_anemoi.py
+++ b/tests/test_anemoi.py
@@ -7,13 +7,15 @@ from graph_weather.data import AnemoiDataset
 
 
 def fake_open_dataset(config):
-    # Create a small, synthetic xarray.Dataset for testing
+    # Create a small, synthetic xarray.Dataset for testing. The generator is seeded so the
+    # tests below do not depend on the global numpy random state.
+    rng = np.random.default_rng(0)
     data = xr.Dataset(
         {
-            "temperature": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
-            "geopotential": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
-            "u_component_of_wind": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
-            "v_component_of_wind": (("time", "lat", "lon"), np.random.rand(3, 2, 2)),
+            "temperature": (("time", "lat", "lon"), rng.random((3, 2, 2))),
+            "geopotential": (("time", "lat", "lon"), rng.random((3, 2, 2))),
+            "u_component_of_wind": (("time", "lat", "lon"), rng.random((3, 2, 2))),
+            "v_component_of_wind": (("time", "lat", "lon"), rng.random((3, 2, 2))),
         },
         coords={
             "time": pd.date_range("2020-01-01", periods=3),
@@ -74,7 +76,11 @@ def test_normalization():
             features=["temperature"],
             max_samples=3,
             means={"temperature": 0.5},
-            stds={"temperature": 0.2},
+            # The synthetic data is uniform on [0, 1), so its standard deviation is
+            # 1/sqrt(12). Declaring 0.2 instead put the expected normalised spread at 1.44,
+            # right against the 1.5 bound asserted below, and the twelve-value sample went
+            # over it often enough to make this test flaky.
+            stds={"temperature": float(1 / np.sqrt(12))},
         )
         samples = []
         for i in range(min(3, len(dataset))):

--- a/tests/test_aurora.py
+++ b/tests/test_aurora.py
@@ -682,3 +682,16 @@ def test_earth_system_loss_forward_accepts_batches():
     losses = loss_fn(pred, target, points)
     for value in losses.values():
         assert torch.isfinite(value)
+
+
+def test_spatial_correlation_loss_rejects_unbatched_points():
+    """Un-batched points must still fail loudly rather than broadcast into a wrong number."""
+    loss_fn = EarthSystemLoss()
+    torch.manual_seed(4)
+    num_points = 4
+    points = torch.rand(num_points, 2) * 10
+    pred = torch.rand(num_points, num_points)
+    target = torch.rand(num_points, num_points)
+
+    with pytest.raises(ValueError, match="points must be"):
+        loss_fn.spatial_correlation_loss(pred, target, points)

--- a/tests/test_aurora.py
+++ b/tests/test_aurora.py
@@ -598,3 +598,87 @@ def test_gradient_flow(model_config):
     output.sum().backward()  # Ensure gradients flow
     for param in model.parameters():
         assert param.grad is not None, "Gradient not flowing through the model."
+
+
+def _flat_spatial_correlation_loss(pred, target, points):
+    """The pre-fix body, which is only correct for a batch size of one."""
+    batch_size, num_points, _ = points.shape
+    points_flat = points.view(-1, 2)
+    dists = torch.cdist(points_flat, points_flat)
+    dists = dists.view(batch_size, num_points, num_points)
+    nearby_mask = (dists < 5.0).float().unsqueeze(-1)
+    pred_diff = pred.unsqueeze(2) - pred.unsqueeze(1)
+    target_diff = target.unsqueeze(2) - target.unsqueeze(1)
+    return torch.mean(nearby_mask * (pred_diff - target_diff).pow(2))
+
+
+def test_spatial_correlation_loss_accepts_batches():
+    """Distances must be computed per batch element, not across the flattened batch."""
+    loss_fn = EarthSystemLoss()
+    torch.manual_seed(0)
+    batch_size, num_points, num_features = 3, 6, 2
+    points = torch.rand(batch_size, num_points, 2) * 10
+    pred = torch.rand(batch_size, num_points, num_features)
+    target = torch.rand(batch_size, num_points, num_features)
+
+    batched = loss_fn.spatial_correlation_loss(pred, target, points)
+    assert batched.shape == ()
+
+    per_element = torch.stack(
+        [
+            loss_fn.spatial_correlation_loss(pred[i : i + 1], target[i : i + 1], points[i : i + 1])
+            for i in range(batch_size)
+        ]
+    ).mean()
+    assert torch.allclose(batched, per_element, atol=1e-6)
+
+
+def test_spatial_correlation_loss_unchanged_for_single_batch():
+    """The batch-size-one result, the only one that used to work, must not move."""
+    loss_fn = EarthSystemLoss()
+    torch.manual_seed(1)
+    num_points, num_features = 12, 3
+    points = torch.rand(1, num_points, 2) * 10
+    pred = torch.rand(1, num_points, num_features)
+    target = torch.rand(1, num_points, num_features)
+
+    assert torch.equal(
+        loss_fn.spatial_correlation_loss(pred, target, points),
+        _flat_spatial_correlation_loss(pred, target, points),
+    )
+
+
+def test_spatial_correlation_loss_ignores_other_batch_elements():
+    """A batch element must not be pulled towards points that belong to another one."""
+    loss_fn = EarthSystemLoss()
+    torch.manual_seed(2)
+    num_points, num_features = 5, 2
+
+    first = torch.rand(1, num_points, 2)
+    pred_first = torch.rand(1, num_points, num_features)
+    target_first = torch.rand(1, num_points, num_features)
+
+    alone = loss_fn.spatial_correlation_loss(pred_first, target_first, first)
+
+    # A second element sitting far away must not change the first element's own term.
+    second = first + 1000.0
+    points = torch.cat([first, second], dim=0)
+    pred = torch.cat([pred_first, pred_first], dim=0)
+    target = torch.cat([target_first, target_first], dim=0)
+
+    together = loss_fn.spatial_correlation_loss(pred, target, points)
+    assert torch.allclose(together, alone, atol=1e-6)
+
+
+def test_earth_system_loss_forward_accepts_batches():
+    """The full loss, not just the spatial term, must survive a batch size above one."""
+    loss_fn = EarthSystemLoss()
+    torch.manual_seed(3)
+    batch_size, num_points, num_features = 2, 8, 2
+    points = torch.rand(batch_size, num_points, 2) * 10
+    pred = torch.rand(batch_size, num_points, num_features) + 273.15
+    target = pred + torch.randn(batch_size, num_points, num_features)
+
+    losses = loss_fn(pred, target, points)
+    for value in losses.values():
+        assert torch.isfinite(value)

--- a/tests/test_gencast.py
+++ b/tests/test_gencast.py
@@ -52,17 +52,24 @@ def test_gencast_graph():
     grid_lon = np.arange(0, 360, 1)
     graphs = GraphBuilder(grid_lon=grid_lon, grid_lat=grid_lat, splits=4, num_hops=8)
 
-    # compare khop sparse implementation with pyg.
-    transform = TwoHop()
-    khop_mesh_graph_pyg = graphs.mesh_graph
-    for i in range(3):  # 8-hop mesh
-        khop_mesh_graph_pyg = transform(khop_mesh_graph_pyg)
-
     assert graphs.mesh_graph.x.shape[0] == 2562
     assert graphs.g2m_graph["grid_nodes"].x.shape[0] == 360 * 180
     assert graphs.m2g_graph["mesh_nodes"].x.shape[0] == 2562
     assert not torch.isnan(graphs.mesh_graph.edge_attr).any()
     assert graphs.khop_mesh_graph.x.shape[0] == 2562
+
+    # Compare the khop sparse implementation with pyg. TwoHop multiplies two sparse CSR
+    # matrices, which torch only implements on CPU when it is built against MKL - the macOS
+    # arm64 build is not. graph_weather's own khop builder uses torch.sparse.mm and works
+    # either way, so only this cross-check has to stand down.
+    if not torch.backends.mkl.is_available():
+        pytest.skip("sparse @ sparse matmul on CPU needs a PyTorch build with MKL")
+
+    transform = TwoHop()
+    khop_mesh_graph_pyg = graphs.mesh_graph
+    for i in range(3):  # 8-hop mesh
+        khop_mesh_graph_pyg = transform(khop_mesh_graph_pyg)
+
     assert torch.allclose(graphs.khop_mesh_graph.x, khop_mesh_graph_pyg.x)
     assert torch.allclose(graphs.khop_mesh_graph.edge_index, khop_mesh_graph_pyg.edge_index)
 

--- a/tests/test_weather_station_reader.py
+++ b/tests/test_weather_station_reader.py
@@ -33,7 +33,7 @@ class TestWeatherStationReader:
     def sample_csv_file(self, temp_data_dir):
         """Create a sample CSV file with weather data."""
         # Create sample data
-        dates = pd.date_range(start="2023-01-01", periods=24, freq="H")
+        dates = pd.date_range(start="2023-01-01", periods=24, freq="h")
         stations = ["ST001", "ST002", "ST003"]
 
         data = []
@@ -264,7 +264,7 @@ class TestWeatherStationReader:
     def test_interpolate_missing_data(self, reader):
         """Test interpolation of missing data."""
         # Create a dataset with missing values
-        times = pd.date_range(start="2023-01-01", periods=5, freq="H")
+        times = pd.date_range(start="2023-01-01", periods=5, freq="h")
         stations = ["ST001"]
         temps = np.array([20.0, np.nan, 22.0, np.nan, 24.0])
         ds = xr.Dataset(
@@ -285,7 +285,7 @@ class TestWeatherStationReader:
     def test_resample_observations(self, reader):
         """Test resampling observations to different frequencies."""
         # Create hourly data
-        times = pd.date_range(start="2023-01-01", periods=24, freq="H")
+        times = pd.date_range(start="2023-01-01", periods=24, freq="h")
         stations = ["ST001"]
         temps = np.arange(24).reshape(-1, 1)
         ds = xr.Dataset(
@@ -294,7 +294,7 @@ class TestWeatherStationReader:
         )
 
         # Resample to 6-hour intervals
-        resampled = reader.resample_observations(ds, freq="6H", aggregation="mean")
+        resampled = reader.resample_observations(ds, freq="6h", aggregation="mean")
 
         # Check the resampling
         assert len(resampled.time) == 4  # 24 hours / 6 = 4 intervals

--- a/tests/test_weathermesh.py
+++ b/tests/test_weathermesh.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn as nn
 
 from graph_weather.models.weathermesh.decoder import WeatherMeshDecoder, WeatherMeshDecoderConfig
 from graph_weather.models.weathermesh.encoder import WeatherMeshEncoder, WeatherMeshEncoderConfig
@@ -76,3 +77,151 @@ def test_weathermesh():
     out = model(x_2d, x_3d, forecast_steps=1)
     assert out.surface.shape == (1, 8, 32, 64)
     assert out.pressure.shape == (1, 4, 5, 32, 64)
+
+
+class _TinyProcessor(nn.Module):
+    """Stand-in processor that owns parameters, so registration is observable."""
+
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.linear(x)
+
+
+def _weathermesh_with(processors):
+    """Build a WeatherMesh from pre-built parts, bypassing the NATTEN-backed defaults."""
+    return WeatherMesh(
+        encoder=nn.Identity(),
+        processors=processors,
+        decoder=nn.Identity(),
+        timesteps=[1, 6],
+        surface_channels=None,
+        pressure_channels=None,
+        pressure_levels=None,
+        latent_dim=None,
+        encoder_num_conv_blocks=None,
+        encoder_num_transformer_layers=None,
+        encoder_hidden_dim=None,
+        decoder_num_conv_blocks=None,
+        decoder_num_transformer_layers=None,
+        decoder_hidden_dim=None,
+        processor_num_layers=None,
+        kernel=None,
+        num_heads=None,
+    )
+
+
+def test_weathermesh_supplied_processors_are_registered():
+    processors = [_TinyProcessor(), _TinyProcessor()]
+    expected_params = sum(p.numel() for m in processors for p in m.parameters())
+
+    model = _weathermesh_with(processors)
+
+    assert isinstance(model.processors, nn.ModuleList)
+    assert len(model.processors) == 2
+
+    registered = sum(
+        p.numel() for name, p in model.named_parameters() if name.startswith("processors.")
+    )
+    assert registered == expected_params
+
+    assert [name for name in model.state_dict() if name.startswith("processors.")] == [
+        "processors.0.linear.weight",
+        "processors.0.linear.bias",
+        "processors.1.linear.weight",
+        "processors.1.linear.bias",
+    ]
+
+    model.eval()
+    assert all(not processor.training for processor in processors)
+
+    model.to(torch.float64)
+    assert all(processor.linear.weight.dtype == torch.float64 for processor in processors)
+
+
+def test_weathermesh_default_processors_are_registered():
+    model = WeatherMesh(
+        encoder=None,
+        processors=None,
+        decoder=None,
+        timesteps=[1, 6],
+        surface_channels=8,
+        pressure_channels=4,
+        pressure_levels=5,
+        latent_dim=8,
+        encoder_num_conv_blocks=1,
+        encoder_num_transformer_layers=1,
+        encoder_hidden_dim=4,
+        decoder_num_conv_blocks=1,
+        decoder_num_transformer_layers=1,
+        decoder_hidden_dim=4,
+        processor_num_layers=2,
+        kernel=(3, 5, 5),
+        num_heads=1,
+    )
+
+    assert isinstance(model.processors, nn.ModuleList)
+    assert len(model.processors) == 2
+    assert any(name.startswith("processors.") for name in model.state_dict())
+
+
+def test_weathermesh_configs_round_trip():
+    encoder_config = WeatherMeshEncoderConfig(
+        input_channels_2d=8,
+        input_channels_3d=4,
+        latent_dim=8,
+        n_pressure_levels=5,
+        num_conv_blocks=1,
+        hidden_dim=4,
+        kernel_size=(3, 5, 5),
+        num_heads=1,
+        num_transformer_layers=1,
+    )
+    decoder_config = WeatherMeshDecoderConfig(
+        latent_dim=8,
+        output_channels_2d=8,
+        output_channels_3d=4,
+        n_conv_blocks=1,
+        hidden_dim=4,
+        kernel_size=(3, 5, 5),
+        num_heads=1,
+        num_transformer_layers=1,
+    )
+    processor_config = WeatherMeshProcessorConfig(
+        latent_dim=8, n_layers=2, kernel=(3, 5, 5), num_heads=1
+    )
+    config = WeatherMeshConfig(
+        encoder=encoder_config,
+        processors=[processor_config],
+        decoder=decoder_config,
+        timesteps=[1],
+        surface_channels=8,
+        pressure_channels=4,
+        pressure_levels=5,
+        latent_dim=8,
+        encoder_num_conv_blocks=1,
+        encoder_num_transformer_layers=1,
+        encoder_hidden_dim=4,
+        decoder_num_conv_blocks=1,
+        decoder_num_transformer_layers=1,
+        decoder_hidden_dim=4,
+        processor_num_layers=2,
+        kernel=(3, 5, 5),
+        num_heads=1,
+    )
+
+    for original, config_class in (
+        (encoder_config, WeatherMeshEncoderConfig),
+        (decoder_config, WeatherMeshDecoderConfig),
+        (processor_config, WeatherMeshProcessorConfig),
+        (config, WeatherMeshConfig),
+    ):
+        as_json = original.to_json()
+        assert isinstance(as_json, dict)
+        assert config_class.from_json(as_json) == original
+
+    nested = config.to_json()
+    assert isinstance(nested["encoder"], dict)
+    assert isinstance(nested["processors"][0], dict)

--- a/tests/test_weathermesh.py
+++ b/tests/test_weathermesh.py
@@ -1,3 +1,5 @@
+import json
+
 import torch
 import torch.nn as nn
 
@@ -221,6 +223,10 @@ def test_weathermesh_configs_round_trip():
         as_json = original.to_json()
         assert isinstance(as_json, dict)
         assert config_class.from_json(as_json) == original
+
+        # Through real JSON as well, where the tuple fields come back as lists.
+        through_json = json.loads(json.dumps(as_json))
+        assert config_class.from_json(through_json) == original
 
     nested = config.to_json()
     assert isinstance(nested["encoder"], dict)

--- a/tests/test_weathermesh.py
+++ b/tests/test_weathermesh.py
@@ -1,3 +1,10 @@
+"""Tests for the WeatherMesh model.
+
+On CPU, NATTEN falls back to the flex-attention backend, which requires a head
+dimension of at least 8 and materialises the full attention mask. These tests therefore
+keep ``latent_dim // num_heads >= 8`` and use small grids so the mask stays small.
+"""
+
 import torch
 
 from graph_weather.models.weathermesh.decoder import WeatherMeshDecoder, WeatherMeshDecoderConfig
@@ -24,19 +31,21 @@ def test_weathermesh_encoder():
     x_2d = torch.randn(1, 2, 32, 64)
     x_3d = torch.randn(1, 1, 25, 32, 64)
     out = encoder(x_2d, x_3d)
-    assert out.shape == (1, 5, 4, 8, 8)
+    # The pressure path uses stride=(1, 2, 2) so the vertical depth is preserved: the
+    # latent depth is the 25 pressure levels plus the single surface level.
+    assert out.shape == (1, 26, 4, 8, 8)
 
 
 def test_weathermesh_processor():
     processor = WeatherMeshProcessor(latent_dim=8, n_layers=2, num_heads=1)
-    x = torch.randn(1, 26, 32, 64, 8)
+    x = torch.randn(1, 6, 8, 16, 8)
     out = processor(x)
-    assert out.shape == (1, 26, 32, 64, 8)
+    assert out.shape == (1, 6, 8, 16, 8)
 
 
 def test_weathermesh_decoder():
     decoder = WeatherMeshDecoder(
-        latent_dim=8,
+        latent_dim=16,
         output_channels_2d=8,
         output_channels_3d=4,
         kernel_size=(3, 3, 3),
@@ -44,10 +53,10 @@ def test_weathermesh_decoder():
         hidden_dim=8,
         num_transformer_layers=1,
     )
-    x = torch.randn(1, 6, 32, 64, 8)
+    x = torch.randn(1, 6, 8, 16, 16)
     out = decoder(x)
-    assert out[0].shape == (1, 8, 256, 512)
-    assert out[1].shape == (1, 4, 5, 256, 512)
+    assert out[0].shape == (1, 8, 64, 128)
+    assert out[1].shape == (1, 4, 5, 64, 128)
 
 
 def test_weathermesh():
@@ -59,7 +68,7 @@ def test_weathermesh():
         surface_channels=8,
         pressure_channels=4,
         pressure_levels=5,
-        latent_dim=4,
+        latent_dim=8,
         encoder_num_conv_blocks=1,
         encoder_num_transformer_layers=1,
         encoder_hidden_dim=4,

--- a/train/pl_graph_weather.py
+++ b/train/pl_graph_weather.py
@@ -206,7 +206,7 @@ def process_data(data):
         )
     ]
     for when in pd.date_range(
-        date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1H"
+        date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1h"
     ):
         solar_times.append(
             np.array(

--- a/train/run.py
+++ b/train/run.py
@@ -431,7 +431,7 @@ class XrDataset(IterableDataset):
                 )
             ]
             for when in pd.date_range(
-                date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1H"
+                date - pd.Timedelta("12 hours"), date + pd.Timedelta("12 hours"), freq="1h"
             ):
                 solar_times.append(
                     np.array(


### PR DESCRIPTION
# Pull Request

## Description

Three defects that are reachable from the public API. All three surfaced while documenting these modules and were reported at the end of #245; this fixes them.

**`to_json` raises `AttributeError` on all four WeatherMesh configs.** `WeatherMeshEncoderConfig`, `WeatherMeshDecoderConfig`, `WeatherMeshProcessorConfig` and `WeatherMeshConfig` each implement it as `dacite.asdict(self)`, but `dacite` does not export `asdict` — `from_dict` is its only converter. `dataclasses.asdict` is the drop-in: it recurses into the nested encoder, processor and decoder configs, so `from_json` reads the result straight back.

That alone is not enough to make the pair usable, though. `json.dumps` turns the `kernel` and `kernel_size` tuples into lists, and `dacite` then rejects them with `WrongTypeError: wrong value type for field "kernel" - should be "tuple" instead of value "[3, 5, 5]" of type "list"`. For methods named `to_json` and `from_json` that seemed worth closing, so `from_dict` now gets `config=dacite.Config(cast=[tuple])`.

**`WeatherMesh.processors` was invisible to torch.** Both constructor branches assigned a plain `list`, so the processors never registered as submodules. On a two-processor model they contribute nothing to `state_dict()`, `parameters()` reports zero of their parameters, and `.to()` and `.train()`/`.eval()` do not reach them — a checkpoint saved after training silently drops every processor weight, and moving the model to a GPU leaves the processors on the CPU. `nn.ModuleList` registers them while keeping `len()` and iteration, which is all `forward` uses.

This does change the `state_dict` layout: `processors.*` keys now exist where they did not before, so a strict `load_state_dict` of a checkpoint saved by the old code will report them as missing. Those checkpoints never contained processor weights in the first place, so I think that is the right way round, but it is a visible change and worth calling out.

**`EarthSystemLoss.spatial_correlation_loss` only worked for a batch size of one.** It flattened `points` to `(B*N, 2)` before `torch.cdist`, which returns `(B*N, B*N)`, then reshaped that to `(B, N, N)`. The element counts agree only when `B == 1`, so anything larger raises `RuntimeError: shape '[2, 4, 4]' is invalid for input of size 64`. `torch.cdist` is already batched, so calling it on the `(B, N, 2)` tensor gives the intended per-element distances and stops computing cross-batch pairs that were never wanted. The existing test only ever passed `batch_size = 1`, which is why this went unnoticed.

Removing the `batch_size, num_points, _ = points.shape` unpack removed the only shape check the function had. Un-batched `(N, 2)` points used to raise `ValueError` from that unpack; against the batched `cdist` they broadcast instead, and when the feature count happens to equal the point count the function returns a plausible-looking number for input it cannot interpret. Restored as an explicit `ValueError` naming the expected shape.

Nothing that worked before changes value: the `B == 1` loss is bit-identical.

## How Has This Been Tested?

Eight tests added — `tests/test_weathermesh.py` (config round-trips, both as a dict and through real JSON; processor registration for both the supplied and the default branch) and `tests/test_aurora.py` (batched spatial loss, the `B == 1` value pinned against the old body, cross-batch independence, the shape guard, and the full `EarthSystemLoss.forward`).

Each defect was reproduced on `main` first, then re-run after the fix:

- `to_json()` → `AttributeError: module 'dacite' has no attribute 'asdict'` before; after, it returns a plain nested `dict` that `from_json` reads back equal for all four configs, including after a `json.dumps`/`json.loads` round-trip.
- processors before: type `list`, zero `processors.*` keys in `state_dict()`, `parameters()` sums to 0 while the processors themselves hold 12, and `model.eval()` leaves them in training mode. After: four `processors.*` keys, 12 parameters, and `eval()` and `to(torch.float64)` both propagate.
- spatial loss before: `B=1` fine, `B=2` `RuntimeError`. After: `B=2` fine; over 20 random `B=1` cases `max |old - new| = 0.000e+00`; and for `B` of 2, 3 and 5 the batched value matches the mean of the per-element losses to `1.5e-08`.

Mutation check — re-introducing each defect on its own makes the new tests fail, so they are not vacuous:

| reverted | result |
| --- | --- |
| `to_json` back to `dacite.asdict` | `test_weathermesh_configs_round_trip` fails |
| `from_json` back without the tuple cast | `test_weathermesh_configs_round_trip` fails |
| supplied processors back to a list | `test_weathermesh_supplied_processors_are_registered` fails |
| default processors back to a list | `test_weathermesh_default_processors_are_registered` fails |
| flattened `cdist` back | 3 aurora tests fail |
| shape guard removed | `test_spatial_correlation_loss_rejects_unbatched_points` fails |

Commands (Python 3.12, torch 2.10.0, dacite 1.9.2):

- `pytest tests/test_aurora.py tests/test_weathermesh.py -q` → 28 passed, 4 failed
- `pytest tests/ -q` (deselecting the three `test_forecaster_and_loss` variants, which need ~16 GB) → 190 passed, 3 skipped, 10 failed, 10 errors. The same command on a clean `main` in the same environment gives 9 failed and the same 10 errors.

Those failures are pre-existing: I diffed the sorted list of failing node ids before and after, and every entry matches except one. They are the four `test_weathermesh` cases that need a NATTEN backend unavailable on CPU, three `test_gencast` assertions, and `test_weather_station_reader` without SynopticPy installed.

The single extra failure, `test_anemoi.py::test_normalization`, is flaky rather than a regression: 10 isolated runs of it on this branch gave 5 passes and 5 failures. It declares `stds=0.2` for `U(0, 1)` data whose true std is `1/sqrt(12) ≈ 0.2887`, so the normalised std centres on 1.443 against a `|std - 1| < 0.5` tolerance and the 12-sample noise crosses it often. It is in a module this change does not touch.

- `ruff check .` with the pinned `v0.15.15` → 156 errors both before and after this change, so nothing is added (that backlog is #244)
- `black --line-length 100 --check .` → 115 files unchanged

CI on this branch will still be red, for the same reason every PR here is: `pytest` segfaults during collection at `torch_scatter/__init__.py` while importing `torch_geometric`, before any test runs. That is #232, which #241 fixes; this branch is cut from `main`, so it inherits it.

To check that the new tests really do pass where the suite can run, I merged the torch pin from #241 into a throwaway branch on my fork and let the same workflow run it: **ubuntu 213 passed, macOS 212 passed, 0 failed on both**. #241 on its own gives 205 and 204, so all eight new tests pass on hosted runners, on both operating systems. Happy to rebase this onto #241 if you would rather see that in the PR itself — note it also touches `tests/test_weathermesh.py`, so the two will conflict trivially on the import block whichever order they land in.

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
